### PR TITLE
Init worker in separate startup function

### DIFF
--- a/src/blueapi/core/controller.py
+++ b/src/blueapi/core/controller.py
@@ -5,6 +5,7 @@ from typing import Any, Mapping, Optional
 
 from bluesky import RunEngine
 
+from blueapi.utils import concurrent_future_to_aio_future
 from blueapi.worker import RunEngineWorker, RunPlan, Worker, run_worker_in_own_thread
 
 from .bluesky_types import Plan
@@ -17,6 +18,10 @@ class BlueskyControllerBase(ABC):
     """
     Object to control Bluesky, bridge between API and worker
     """
+
+    @abstractmethod
+    async def run_workers(self) -> None:
+        ...
 
     @abstractmethod
     async def run_plan(self, __name: str, __params: Mapping[str, Any]) -> None:
@@ -59,8 +64,10 @@ class BlueskyController(BlueskyControllerBase):
 
         if worker is None:
             worker = make_default_worker()
-            run_worker_in_own_thread(worker)  # TODO: Don't do this in __init__
         self._worker = worker
+
+    async def run_workers(self) -> None:
+        await concurrent_future_to_aio_future(run_worker_in_own_thread(self._worker))
 
     async def run_plan(self, name: str, params: Mapping[str, Any]) -> None:
         LOGGER.info(f"Asked to run plan {name} with {params}")

--- a/src/blueapi/example/server/app.py
+++ b/src/blueapi/example/server/app.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import uuid
 from typing import Any, List, Mapping
@@ -26,6 +27,11 @@ controller = BlueskyController(ctx)
 
 
 app = FastAPI()
+
+
+@app.on_event("startup")
+async def app_startup():
+    asyncio.create_task(controller.run_workers())
 
 
 @app.get("/plan")

--- a/src/blueapi/utils/__init__.py
+++ b/src/blueapi/utils/__init__.py
@@ -1,3 +1,4 @@
+from .aio_threading import concurrent_future_to_aio_future
 from .thread_exception import handle_all_exceptions
 
-__all__ = ["handle_all_exceptions"]
+__all__ = ["handle_all_exceptions", "concurrent_future_to_aio_future"]

--- a/src/blueapi/utils/aio_threading.py
+++ b/src/blueapi/utils/aio_threading.py
@@ -1,0 +1,26 @@
+import asyncio
+from asyncio import Future as AioFuture
+from concurrent.futures import Future as ConcurrentFuture
+from typing import Optional
+
+
+def concurrent_future_to_aio_future(
+    concurrent_future: ConcurrentFuture,
+    loop: Optional[asyncio.AbstractEventLoop] = None,
+) -> AioFuture:
+    aio_future: AioFuture = AioFuture(loop=loop)
+
+    def transcribe(future: ConcurrentFuture) -> None:
+        ex = future.exception()
+        if ex is not None:
+            aio_future.set_exception(ex)
+        rs = future.result()
+        if rs is not None:
+            aio_future.set_result(rs)
+
+    def on_complete(future: ConcurrentFuture) -> None:
+        aio_future.get_loop().call_soon_threadsafe(transcribe, future)
+
+    concurrent_future.add_done_callback(on_complete)
+
+    return aio_future

--- a/src/blueapi/worker/multithread.py
+++ b/src/blueapi/worker/multithread.py
@@ -1,5 +1,5 @@
 import logging
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import Future, ThreadPoolExecutor
 from typing import Optional, TypeVar
 
 from blueapi.utils import handle_all_exceptions
@@ -13,7 +13,7 @@ T = TypeVar("T")
 
 def run_worker_in_own_thread(
     worker: Worker[T], executor: Optional[ThreadPoolExecutor] = None
-) -> None:
+) -> Future:
     """
     Helper function, make a worker run in a new thread managed by a ThreadPoolExecutor
 
@@ -24,7 +24,7 @@ def run_worker_in_own_thread(
 
     if executor is None:
         executor = ThreadPoolExecutor(1, "run-engine-worker")
-    executor.submit(_run_worker_thread, worker)
+    return executor.submit(_run_worker_thread, worker)
 
 
 @handle_all_exceptions


### PR DESCRIPTION
* Remove worker initialization from the constructor
* Use a separate startup function instead
* Wrap wroker `run_forever` in an asyncio `Future`