### PR TITLE
Workaround scanspec serialization issue wtih non-string axes

### DIFF
--- a/src/blueapi/cli/amq.py
+++ b/src/blueapi/cli/amq.py
@@ -29,7 +29,7 @@ class AmqClient:
         def on_event_wrapper(ctx: MessageContext, event: TaskEvent) -> None:
             if on_event is not None:
                 on_event(event)
-            if event.task.is_complete():
+            if event.is_task_terminated():
                 complete.set()
 
         self.app.subscribe(

--- a/src/blueapi/cli/cli.py
+++ b/src/blueapi/cli/cli.py
@@ -84,7 +84,7 @@ def run_plan(ctx, name: str, parameters: str) -> None:
 
     def handle_event(event: TaskEvent) -> None:
         renderer.update(event.statuses)
-        if event.task.is_complete():
+        if event.is_task_terminated():
             print("")
             print("")
             print("")

--- a/src/blueapi/messaging/stomptemplate.py
+++ b/src/blueapi/messaging/stomptemplate.py
@@ -72,7 +72,11 @@ class StompMessagingTemplate(MessagingTemplate):
     def send(
         self, destination: str, obj: Any, on_reply: Optional[MessageListener] = None
     ) -> None:
-        self._send_str(destination, json.dumps(serialize(obj)), on_reply)
+        self._send_str(
+            destination,
+            json.dumps(serialize(obj)),
+            on_reply,
+        )
 
     def _send_str(
         self,

--- a/src/blueapi/worker/event.py
+++ b/src/blueapi/worker/event.py
@@ -1,12 +1,9 @@
 from dataclasses import dataclass, field
 from enum import Enum
-from types import MappingProxyType
 from typing import Mapping, Optional, Union
 
 from bluesky.run_engine import RunEngineStateMachine
 from super_state_machine.extras import PropertyMachine, ProxyString
-
-from blueapi.worker.task import ActiveTask
 
 from .task import TaskState
 

--- a/src/blueapi/worker/event.py
+++ b/src/blueapi/worker/event.py
@@ -1,11 +1,14 @@
 from dataclasses import dataclass, field
 from enum import Enum
+from types import MappingProxyType
 from typing import Mapping, Optional, Union
 
 from bluesky.run_engine import RunEngineStateMachine
 from super_state_machine.extras import PropertyMachine, ProxyString
 
 from blueapi.worker.task import ActiveTask
+
+from .task import TaskState
 
 # The RunEngine can return any of these three types as its state
 RawRunEngineState = Union[PropertyMachine, ProxyString, str]
@@ -68,6 +71,10 @@ class TaskEvent:
     An event representing a progress update on a Task
     """
 
-    task: ActiveTask
+    name: str
+    state: TaskState
     error: Optional[str] = None
     statuses: Mapping[str, StatusView] = field(default_factory=dict)
+
+    def is_task_terminated(self) -> bool:
+        return self.state in (TaskState.COMPLETE, TaskState.FAILED)

--- a/src/blueapi/worker/task.py
+++ b/src/blueapi/worker/task.py
@@ -100,6 +100,3 @@ class ActiveTask:
     name: str
     task: Task
     state: TaskState = field(default=TaskState.PENDING)
-
-    def is_complete(self) -> bool:
-        return self.state in _COMPLETE_TASK_STATES


### PR DESCRIPTION
Temporary workaround for #50 

When scanspecs are embedded inside events, they may cause failures when attempting to serialise because their axes are arbitrary `Movable`s. This PR Adds a temporary workaround to ensure the axes are serialized to sensible strings. Long-term solution may be to move to pydantic or similar, requires further investigation. 

This PR also tidies up the structure of task events and doesn't embed the entire task.