### PR TITLE
Explicitly tag empty-bodied functions that are supposed to be empty-bodied

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -73,7 +73,6 @@ console_scripts =
 [mypy]
 # Ignore missing stubs for modules we use
 ignore_missing_imports = True
-allow_empty_bodies = True
 
 [isort]
 profile=black

--- a/setup.cfg
+++ b/setup.cfg
@@ -73,6 +73,7 @@ console_scripts =
 [mypy]
 # Ignore missing stubs for modules we use
 ignore_missing_imports = True
+allow_empty_bodies = True
 
 [isort]
 profile=black

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -16,27 +16,27 @@ from blueapi.core import (
 #
 
 
-def has_no_params() -> MsgGenerator:
+def has_no_params() -> MsgGenerator:  # type: ignore
     ...
 
 
-def has_one_param(foo: int) -> MsgGenerator:
+def has_one_param(foo: int) -> MsgGenerator:  # type: ignore
     ...
 
 
-def has_some_params(foo: int, bar: str) -> MsgGenerator:
+def has_some_params(foo: int, bar: str) -> MsgGenerator:  # type: ignore
     ...
 
 
-def has_typeless_param(foo) -> MsgGenerator:
+def has_typeless_param(foo) -> MsgGenerator:  # type: ignore
     ...
 
 
-def has_typed_and_typeless_params(foo: int, bar) -> MsgGenerator:
+def has_typed_and_typeless_params(foo: int, bar) -> MsgGenerator:  # type: ignore
     ...
 
 
-def has_typeless_params(foo, bar) -> MsgGenerator:
+def has_typeless_params(foo, bar) -> MsgGenerator:  # type: ignore
     ...
 
 

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -79,10 +79,12 @@ def devicey_context(sim_motor: SynAxis, sim_detector: SynGauss) -> BlueskyContex
 
 
 class SomeConfigurable:
-    def read_configuration(self) -> SyncOrAsync[Dict[str, Reading]]:
+    def read_configuration(self) -> SyncOrAsync[Dict[str, Reading]]:  # type: ignore
         ...
 
-    def describe_configuration(self) -> SyncOrAsync[Dict[str, Descriptor]]:
+    def describe_configuration(  # type: ignore
+        self,
+    ) -> SyncOrAsync[Dict[str, Descriptor]]:
         ...
 
 


### PR DESCRIPTION
Mypy 0.991 disallows empty function bodies by default, see https://mypy-lang.blogspot.com/2022/11/mypy-0990-released.html

While I have mixed feelings about this change I do find empty bodies useful, for example for dummy functions in tests:
```python
def my_test_function() -> int:
    ...

def test_something():
    assert something_to_do_with(my_test_function.__annotations__)
```
So I have added config to disable it. Empty functions are not widely spread and I could probably also remove them all.