### PR TITLE
Downgrade scanspec because of breaking change

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "ophyd",
     "apischema",
     "stomp.py",
-    "scanspec",
+    "scanspec<=0.5.5",
     "PyYAML",
     "click",
 ]


### PR DESCRIPTION
Related issue: https://github.com/DiamondLightSource/blueapi/issues/57