### PR TITLE
Disable content length header on stomp messages

### DIFF
--- a/src/blueapi/messaging/stomptemplate.py
+++ b/src/blueapi/messaging/stomptemplate.py
@@ -62,7 +62,9 @@ class StompMessagingTemplate(MessagingTemplate):
 
     @classmethod
     def autoconfigured(cls, config: StompConfig) -> MessagingTemplate:
-        return cls(stomp.Connection([(config.host, config.port)]))
+        return cls(
+            stomp.Connection([(config.host, config.port)], auto_content_length=False)
+        )
 
     @property
     def destinations(self) -> DestinationProvider:


### PR DESCRIPTION
For better interoperability with ActiveMQ and JMS applications, see stomp.py/issues/216