### PR TITLE
Use task response

### DIFF
--- a/src/blueapi/cli/amq.py
+++ b/src/blueapi/cli/amq.py
@@ -7,6 +7,7 @@ from blueapi.service.model import (
     DeviceResponse,
     PlanRequest,
     PlanResponse,
+    TaskResponse,
 )
 from blueapi.worker import TaskEvent
 
@@ -40,9 +41,10 @@ class AmqClient:
             self.app.destinations.topic("public.worker.event.task"), on_event_wrapper
         )
         # self.app.send("worker.run", {"name": name, "params": params})
-        task_id = self.app.send_and_recieve(
-            "worker.run", {"name": name, "params": params}
-        ).result(timeout=5.0)
+        task_response = self.app.send_and_recieve(
+            "worker.run", {"name": name, "params": params}, reply_type=TaskResponse
+        ).result(5.0)
+        task_id = task_response.task_name
 
         if timeout is not None:
             complete.wait(timeout)

--- a/src/blueapi/service/app.py
+++ b/src/blueapi/service/app.py
@@ -16,6 +16,7 @@ from .model import (
     PlanModel,
     PlanRequest,
     PlanResponse,
+    TaskResponse,
 )
 
 logging.basicConfig(level=logging.INFO)
@@ -68,7 +69,8 @@ class Service:
 
         reply_queue = message_context.reply_destination
         if reply_queue is not None:
-            self._template.send(reply_queue, name)
+            response = TaskResponse(name)
+            self._template.send(reply_queue, response)
 
     def _get_plans(self, message_context: MessageContext, message: PlanRequest) -> None:
         plans = list(map(PlanModel.from_plan, self._ctx.plans.values()))


### PR DESCRIPTION
The `TaskResponse` model was unused, a raw string was being sent as a response