### PR TITLE
Propgate worker errors back to user via message bus

### DIFF
--- a/src/blueapi/cli/amq.py
+++ b/src/blueapi/cli/amq.py
@@ -1,4 +1,5 @@
 import threading
+from concurrent.futures import Future
 from typing import Any, Callable, List, Mapping, Optional, TypeVar, Union
 
 from blueapi.messaging import MessageContext, MessagingTemplate
@@ -9,11 +10,14 @@ from blueapi.service.model import (
     PlanResponse,
     TaskResponse,
 )
-from blueapi.worker import TaskEvent
+from blueapi.worker import StatusEvent, TaskEvent, WorkerEvent, WorkerStatusEvent
 
 T = TypeVar("T")
 
-_Json = Union[List[Any], Mapping[str, Any]]
+
+class BlueskyRemoteError(Exception):
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
 
 
 class AmqClient:
@@ -26,19 +30,24 @@ class AmqClient:
         self,
         name: str,
         params: Mapping[str, Any],
-        on_event: Optional[Callable[[TaskEvent], None]] = None,
+        on_event: Optional[Callable[[WorkerEvent], None]] = None,
         timeout: Optional[float] = None,
     ) -> str:
         complete = threading.Event()
 
-        def on_event_wrapper(ctx: MessageContext, event: TaskEvent) -> None:
+        def on_event_wrapper(ctx: MessageContext, event: WorkerEvent) -> None:
             if on_event is not None:
                 on_event(event)
-            if event.is_task_terminated():
+
+            if (isinstance(event, TaskEvent) and event.is_task_terminated()) or (
+                isinstance(event, WorkerStatusEvent) and event.is_error()
+            ):
                 complete.set()
+                if event.is_error():
+                    raise BlueskyRemoteError(event.error_message or "Unknown error")
 
         self.app.subscribe(
-            self.app.destinations.topic("public.worker.event.task"), on_event_wrapper
+            self.app.destinations.topic("public.worker.event"), on_event_wrapper
         )
         # self.app.send("worker.run", {"name": name, "params": params})
         task_response = self.app.send_and_recieve(

--- a/src/blueapi/cli/amq.py
+++ b/src/blueapi/cli/amq.py
@@ -10,7 +10,7 @@ from blueapi.service.model import (
     PlanResponse,
     TaskResponse,
 )
-from blueapi.worker import StatusEvent, TaskEvent, WorkerEvent, WorkerStatusEvent
+from blueapi.worker import ProgressEvent, TaskEvent, WorkerEvent, WorkerStatusEvent
 
 T = TypeVar("T")
 

--- a/src/blueapi/cli/amq.py
+++ b/src/blueapi/cli/amq.py
@@ -1,6 +1,5 @@
 import threading
-from concurrent.futures import Future
-from typing import Any, Callable, List, Mapping, Optional, TypeVar, Union
+from typing import Any, Callable, Mapping, Optional, TypeVar
 
 from blueapi.messaging import MessageContext, MessagingTemplate
 from blueapi.service.model import (
@@ -10,7 +9,7 @@ from blueapi.service.model import (
     PlanResponse,
     TaskResponse,
 )
-from blueapi.worker import ProgressEvent, TaskEvent, WorkerEvent, WorkerStatusEvent
+from blueapi.worker import TaskEvent, WorkerEvent, WorkerStatusEvent
 
 T = TypeVar("T")
 

--- a/src/blueapi/cli/cli.py
+++ b/src/blueapi/cli/cli.py
@@ -1,18 +1,17 @@
-import itertools
 import json
 import logging
 from pathlib import Path
-from typing import Dict, Mapping, Optional
+from typing import Optional
 
 import click
-from tqdm import tqdm
 
 from blueapi import __version__
 from blueapi.config import StompConfig
 from blueapi.messaging import StompMessagingTemplate
-from blueapi.worker import StatusView, TaskEvent
+from blueapi.worker import TaskEvent
 
 from .amq import AmqClient
+from .updates import CliEventRenderer
 
 
 @click.group(invoke_without_command=True)
@@ -91,52 +90,5 @@ def get_devices(ctx) -> None:
 @click.pass_context
 def run_plan(ctx, name: str, parameters: str) -> None:
     client: AmqClient = ctx.obj["client"]
-
-    renderer = ProgressBarRenderer()
-
-    def handle_event(event: TaskEvent) -> None:
-        renderer.update(event.statuses)
-        if event.is_task_terminated():
-            print("")
-            print("")
-            print("")
-            print("DONE")
-
-    client.run_plan(name, json.loads(parameters), handle_event, timeout=120.0)
-
-
-_BAR_FMT = "{desc}: |{bar}| {percentage:3.0f}% [{elapsed}/{remaining}]"
-
-
-class ProgressBarRenderer:
-    _bars: Dict[str, tqdm]
-    _count: itertools.count
-
-    def __init__(self) -> None:
-        self._bars = {}
-        self._count = itertools.count()
-
-    def update(self, status_view: Mapping[str, StatusView]) -> None:
-        for name, view in status_view.items():
-            if name not in self._bars:
-                pos = next(self._count)
-                self._bars[name] = tqdm(
-                    position=pos,
-                    total=1.0,
-                    initial=0.0,
-                    bar_format=_BAR_FMT,
-                )
-            self._update(name, view)
-
-    def _update(self, name: str, view: StatusView) -> None:
-        bar = self._bars[name]
-        if (
-            view.current is not None
-            and view.target is not None
-            and view.initial is not None
-            and view.percentage is not None
-            and view.time_elapsed is not None
-        ):
-            bar.desc = view.display_name
-            bar.update(view.percentage - bar.n)
-            bar.unit = view.unit
+    renderer = CliEventRenderer()
+    client.run_plan(name, json.loads(parameters), renderer.render_event, timeout=120.0)

--- a/src/blueapi/cli/cli.py
+++ b/src/blueapi/cli/cli.py
@@ -90,4 +90,10 @@ def get_devices(ctx) -> None:
 def run_plan(ctx, name: str, parameters: str) -> None:
     client: AmqClient = ctx.obj["client"]
     renderer = CliEventRenderer()
-    client.run_plan(name, json.loads(parameters), renderer.render_event, timeout=120.0)
+    client.run_plan(
+        name,
+        json.loads(parameters),
+        renderer.on_worker_event,
+        renderer.on_progress_event,
+        timeout=120.0,
+    )

--- a/src/blueapi/cli/cli.py
+++ b/src/blueapi/cli/cli.py
@@ -8,7 +8,6 @@ import click
 from blueapi import __version__
 from blueapi.config import StompConfig
 from blueapi.messaging import StompMessagingTemplate
-from blueapi.worker import TaskEvent
 
 from .amq import AmqClient
 from .updates import CliEventRenderer

--- a/src/blueapi/cli/updates.py
+++ b/src/blueapi/cli/updates.py
@@ -3,7 +3,7 @@ from typing import Dict, Mapping, Optional, Union
 
 from tqdm import tqdm
 
-from blueapi.worker import StatusEvent, StatusView, TaskEvent, WorkerEvent
+from blueapi.worker import ProgressEvent, StatusView, TaskEvent, WorkerEvent
 
 _BAR_FMT = "{desc}: |{bar}| {percentage:3.0f}% [{elapsed}/{remaining}]"
 
@@ -55,11 +55,11 @@ class CliEventRenderer:
         self._pbar_renderer = pbar_renderer or ProgressBarRenderer()
 
     def render_event(self, event: WorkerEvent) -> None:
-        if isinstance(event, StatusEvent) and self._relates_to_task(event):
+        if isinstance(event, ProgressEvent) and self._relates_to_task(event):
             self._pbar_renderer.update(event.statuses)
         elif isinstance(event, TaskEvent) and self._relates_to_task(event):
             print("")
             print(str(event.state))
 
-    def _relates_to_task(self, event: Union[TaskEvent, StatusEvent]) -> bool:
+    def _relates_to_task(self, event: Union[TaskEvent, ProgressEvent]) -> bool:
         return self._task_name is None or self._task_name == event.task_name

--- a/src/blueapi/cli/updates.py
+++ b/src/blueapi/cli/updates.py
@@ -1,0 +1,65 @@
+import itertools
+from typing import Dict, Mapping, Optional, Union
+
+from tqdm import tqdm
+
+from blueapi.worker import StatusEvent, StatusView, TaskEvent, WorkerEvent
+
+_BAR_FMT = "{desc}: |{bar}| {percentage:3.0f}% [{elapsed}/{remaining}]"
+
+
+class ProgressBarRenderer:
+    _bars: Dict[str, tqdm]
+    _count: itertools.count
+
+    def __init__(self) -> None:
+        self._bars = {}
+        self._count = itertools.count()
+
+    def update(self, status_view: Mapping[str, StatusView]) -> None:
+        for name, view in status_view.items():
+            if name not in self._bars:
+                pos = next(self._count)
+                self._bars[name] = tqdm(
+                    position=pos,
+                    total=1.0,
+                    initial=0.0,
+                    bar_format=_BAR_FMT,
+                )
+            self._update(name, view)
+
+    def _update(self, name: str, view: StatusView) -> None:
+        bar = self._bars[name]
+        if (
+            view.current is not None
+            and view.target is not None
+            and view.initial is not None
+            and view.percentage is not None
+            and view.time_elapsed is not None
+        ):
+            bar.desc = view.display_name
+            bar.update(view.percentage - bar.n)
+            bar.unit = view.unit
+
+
+class CliEventRenderer:
+    _task_name: Optional[str]
+    _pbar_renderer: ProgressBarRenderer
+
+    def __init__(
+        self,
+        task_name: Optional[str] = None,
+        pbar_renderer: Optional[ProgressBarRenderer] = None,
+    ) -> None:
+        self._task_name = task_name
+        self._pbar_renderer = pbar_renderer or ProgressBarRenderer()
+
+    def render_event(self, event: WorkerEvent) -> None:
+        if isinstance(event, StatusEvent) and self._relates_to_task(event):
+            self._pbar_renderer.update(event.statuses)
+        elif isinstance(event, TaskEvent) and self._relates_to_task(event):
+            print("")
+            print(str(event.state))
+
+    def _relates_to_task(self, event: Union[TaskEvent, StatusEvent]) -> bool:
+        return self._task_name is None or self._task_name == event.task_name

--- a/src/blueapi/service/app.py
+++ b/src/blueapi/service/app.py
@@ -7,7 +7,7 @@ from blueapi.config import ApplicationConfig
 from blueapi.core import BlueskyContext, DataEvent
 from blueapi.messaging import MessageContext, MessagingTemplate, StompMessagingTemplate
 from blueapi.utils import ConfigLoader
-from blueapi.worker import RunEngineWorker, RunPlan, TaskEvent, Worker, WorkerEvent
+from blueapi.worker import RunEngineWorker, RunPlan, Worker, WorkerEvent
 
 from .model import (
     DeviceModel,

--- a/src/blueapi/service/app.py
+++ b/src/blueapi/service/app.py
@@ -36,7 +36,6 @@ class Service:
     def run(self) -> None:
         logging.basicConfig(level=self._config.logging.level)
         self._worker.worker_events.subscribe(self._on_worker_event)
-        self._worker.task_events.subscribe(self._on_task_event)
         self._worker.data_events.subscribe(self._on_data_event)
 
         self._template.connect()
@@ -50,11 +49,6 @@ class Service:
     def _on_worker_event(self, event: WorkerEvent) -> None:
         self._template.send(
             self._template.destinations.topic("public.worker.event"), event
-        )
-
-    def _on_task_event(self, event: TaskEvent) -> None:
-        self._template.send(
-            self._template.destinations.topic("public.worker.event.task"), event
         )
 
     def _on_data_event(self, event: DataEvent) -> None:

--- a/src/blueapi/service/app.py
+++ b/src/blueapi/service/app.py
@@ -7,7 +7,7 @@ from blueapi.config import ApplicationConfig
 from blueapi.core import BlueskyContext, DataEvent
 from blueapi.messaging import MessageContext, MessagingTemplate, StompMessagingTemplate
 from blueapi.utils import ConfigLoader
-from blueapi.worker import RunEngineWorker, RunPlan, Worker, WorkerEvent
+from blueapi.worker import ProgressEvent, RunEngineWorker, RunPlan, Worker, WorkerEvent
 
 from .model import (
     DeviceModel,
@@ -37,6 +37,7 @@ class Service:
         logging.basicConfig(level=self._config.logging.level)
         self._worker.worker_events.subscribe(self._on_worker_event)
         self._worker.data_events.subscribe(self._on_data_event)
+        self._worker.progress_events.subscribe(self._on_progress_event)
 
         self._template.connect()
 
@@ -49,6 +50,11 @@ class Service:
     def _on_worker_event(self, event: WorkerEvent) -> None:
         self._template.send(
             self._template.destinations.topic("public.worker.event"), event
+        )
+
+    def _on_progress_event(self, event: ProgressEvent) -> None:
+        self._template.send(
+            self._template.destinations.topic("public.worker.event.progress"), event
         )
 
     def _on_data_event(self, event: DataEvent) -> None:

--- a/src/blueapi/startup/example.py
+++ b/src/blueapi/startup/example.py
@@ -1,7 +1,8 @@
-from ophyd.sim import Syn2DGauss, SynGauss, SynSignal
+from ophyd.sim import Syn2DGauss, SynAxisNoPosition, SynGauss, SynSignal
 
 from blueapi.plans import *  # noqa: F401, F403
-from blueapi.service.simmotor import SynAxisWithMotionEvents
+
+from .simmotor import BrokenSynAxis, SynAxisWithMotionEvents
 
 x = SynAxisWithMotionEvents(name="x", delay=1.0, events_per_move=8)
 y = SynAxisWithMotionEvents(name="y", delay=3.0, events_per_move=24)
@@ -9,6 +10,7 @@ z = SynAxisWithMotionEvents(name="z", delay=2.0, events_per_move=16)
 theta = SynAxisWithMotionEvents(
     name="theta", delay=0.2, events_per_move=12, egu="degrees"
 )
+x_err = BrokenSynAxis(name="x_err", timeout=1.0)
 sample_pressure = SynAxisWithMotionEvents(
     name="sample_pressure", delay=30.0, events_per_move=128, egu="MPa", value=0.101
 )

--- a/src/blueapi/startup/example.py
+++ b/src/blueapi/startup/example.py
@@ -1,4 +1,4 @@
-from ophyd.sim import Syn2DGauss, SynAxisNoPosition, SynGauss, SynSignal
+from ophyd.sim import Syn2DGauss, SynGauss, SynSignal
 
 from blueapi.plans import *  # noqa: F401, F403
 

--- a/src/blueapi/startup/simmotor.py
+++ b/src/blueapi/startup/simmotor.py
@@ -3,7 +3,7 @@ import time as ttime
 from typing import Callable, Optional
 
 from ophyd.sim import SynAxis
-from ophyd.status import MoveStatus
+from ophyd.status import MoveStatus, Status
 
 
 class SynAxisWithMotionEvents(SynAxis):
@@ -81,3 +81,14 @@ class SynAxisWithMotionEvents(SynAxis):
         threading.Thread(target=sleep_and_finish, daemon=True).start()
 
         return st
+
+
+class BrokenSynAxis(SynAxis):
+    _timeout: float
+
+    def __init__(self, *, timeout: float, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self._timeout = timeout
+
+    def set(self, value: float) -> Status:
+        return Status(timeout=self._timeout)

--- a/src/blueapi/worker/__init__.py
+++ b/src/blueapi/worker/__init__.py
@@ -1,27 +1,26 @@
 from .event import (
     ProgressEvent,
     StatusView,
-    TaskEvent,
+    TaskStatus,
     WorkerEvent,
     WorkerState,
     WorkerStatusEvent,
 )
 from .multithread import run_worker_in_own_thread
 from .reworker import RunEngineWorker
-from .task import RunPlan, Task, TaskState
+from .task import RunPlan, Task
 from .worker import Worker
 
 __all__ = [
     "run_worker_in_own_thread",
     "RunEngineWorker",
     "Task",
-    "TaskState",
     "Worker",
     "RunPlan",
     "WorkerEvent",
     "WorkerState",
-    "TaskEvent",
     "StatusView",
     "ProgressEvent",
     "WorkerStatusEvent",
+    "TaskStatus",
 ]

--- a/src/blueapi/worker/__init__.py
+++ b/src/blueapi/worker/__init__.py
@@ -1,11 +1,4 @@
-from .event import (
-    ProgressEvent,
-    StatusView,
-    TaskStatus,
-    WorkerEvent,
-    WorkerState,
-    WorkerStatusEvent,
-)
+from .event import ProgressEvent, StatusView, TaskStatus, WorkerEvent, WorkerState
 from .multithread import run_worker_in_own_thread
 from .reworker import RunEngineWorker
 from .task import RunPlan, Task
@@ -21,6 +14,5 @@ __all__ = [
     "WorkerState",
     "StatusView",
     "ProgressEvent",
-    "WorkerStatusEvent",
     "TaskStatus",
 ]

--- a/src/blueapi/worker/__init__.py
+++ b/src/blueapi/worker/__init__.py
@@ -1,4 +1,11 @@
-from .event import RunnerState, StatusView, TaskEvent, WorkerEvent
+from .event import (
+    RunnerState,
+    StatusEvent,
+    StatusView,
+    TaskEvent,
+    WorkerEvent,
+    WorkerStatusEvent,
+)
 from .multithread import run_worker_in_own_thread
 from .reworker import RunEngineWorker
 from .task import RunPlan, Task, TaskState
@@ -15,4 +22,6 @@ __all__ = [
     "RunnerState",
     "TaskEvent",
     "StatusView",
+    "StatusEvent",
+    "WorkerStatusEvent",
 ]

--- a/src/blueapi/worker/__init__.py
+++ b/src/blueapi/worker/__init__.py
@@ -1,9 +1,9 @@
 from .event import (
-    RunnerState,
-    StatusEvent,
+    ProgressEvent,
     StatusView,
     TaskEvent,
     WorkerEvent,
+    WorkerState,
     WorkerStatusEvent,
 )
 from .multithread import run_worker_in_own_thread
@@ -19,9 +19,9 @@ __all__ = [
     "Worker",
     "RunPlan",
     "WorkerEvent",
-    "RunnerState",
+    "WorkerState",
     "TaskEvent",
     "StatusView",
-    "StatusEvent",
+    "ProgressEvent",
     "WorkerStatusEvent",
 ]

--- a/src/blueapi/worker/event.py
+++ b/src/blueapi/worker/event.py
@@ -11,7 +11,7 @@ RawRunEngineState = Union[PropertyMachine, ProxyString, str]
 
 class WorkerState(Enum):
     """
-    The state of the Runner.
+    The state of the Worker.
     """
 
     IDLE = "IDLE"
@@ -52,12 +52,21 @@ class StatusView:
 
 @dataclass
 class ProgressEvent:
+    """
+    Event describing the progress of processes within a running task,
+    such as moving motors and exposing detectors.
+    """
+
     task_name: str
     statuses: Mapping[str, StatusView] = field(default_factory=dict)
 
 
 @dataclass
 class TaskStatus:
+    """
+    Status of a task the worker is running.
+    """
+
     task_name: str
     task_complete: bool
     task_failed: bool
@@ -65,6 +74,11 @@ class TaskStatus:
 
 @dataclass
 class WorkerEvent:
+    """
+    Event describing the state of the worker and any tasks it's running.
+    Includes error and warning information.
+    """
+
     state: WorkerState
     task_status: Optional[TaskStatus] = None
     errors: List[str] = field(default_factory=list)

--- a/src/blueapi/worker/event.py
+++ b/src/blueapi/worker/event.py
@@ -14,7 +14,7 @@ from .task import TaskState
 RawRunEngineState = Union[PropertyMachine, ProxyString, str]
 
 
-class RunnerState(Enum):
+class WorkerState(Enum):
     """
     The state of the Runner.
     """
@@ -31,10 +31,10 @@ class RunnerState(Enum):
     UNKNOWN = "UNKNOWN"
 
     @classmethod
-    def from_bluesky_state(cls, bluesky_state: RawRunEngineState) -> "RunnerState":
+    def from_bluesky_state(cls, bluesky_state: RawRunEngineState) -> "WorkerState":
         if isinstance(bluesky_state, RunEngineStateMachine.States):
             return cls.from_bluesky_state(bluesky_state.value)
-        return RunnerState(str(bluesky_state).upper())
+        return WorkerState(str(bluesky_state).upper())
 
 
 @dataclass
@@ -89,17 +89,17 @@ class TaskEvent(WorkerEvent):
 
 
 @dataclass
-class StatusEvent(WorkerEvent):
+class ProgressEvent(WorkerEvent):
     task_name: str
     statuses: Mapping[str, StatusView] = field(default_factory=dict)
 
 
 @dataclass
 class WorkerStatusEvent(WorkerEvent):
-    worker_state: RunnerState
+    worker_state: WorkerState
     error_message: Optional[str] = None
 
     def is_error(self) -> bool:
         return self.error_message is not None or (
-            self.worker_state in (RunnerState.UNKNOWN, RunnerState.PANICKED)
+            self.worker_state in (WorkerState.UNKNOWN, WorkerState.PANICKED)
         )

--- a/src/blueapi/worker/event.py
+++ b/src/blueapi/worker/event.py
@@ -53,29 +53,8 @@ class StatusView:
     time_remaining: Optional[float] = None
 
 
-class WorkerEvent:
-    _union: Any = None
-
-    def __init_subclass__(cls, **kwargs):
-        super().__init_subclass__(**kwargs)
-        deserializer(Conversion(identity, source=cls, target=WorkerEvent))
-        WorkerEvent._union = (
-            cls if WorkerEvent._union is None else Union[WorkerEvent._union, cls]
-        )
-        serializer(
-            Conversion(
-                identity, source=WorkerEvent, target=WorkerEvent._union, inherited=False
-            )
-        )
-
-    @serialized
-    @property
-    def type(self) -> str:
-        return type(self).__name__
-
-
 @dataclass
-class ProgressEvent(WorkerEvent):
+class ProgressEvent:
     task_name: str
     statuses: Mapping[str, StatusView] = field(default_factory=dict)
 
@@ -88,7 +67,7 @@ class TaskStatus:
 
 
 @dataclass
-class WorkerStatusEvent(WorkerEvent):
+class WorkerEvent:
     state: WorkerState
     task_status: Optional[TaskStatus] = None
     errors: List[str] = field(default_factory=list)

--- a/src/blueapi/worker/event.py
+++ b/src/blueapi/worker/event.py
@@ -1,10 +1,7 @@
-from abc import ABC
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, List, Literal, Mapping, Optional, Union
+from typing import List, Mapping, Optional, Union
 
-from apischema import deserializer, identity, serialized, serializer
-from apischema.conversions import Conversion
 from bluesky.run_engine import RunEngineStateMachine
 from super_state_machine.extras import PropertyMachine, ProxyString
 

--- a/src/blueapi/worker/task.py
+++ b/src/blueapi/worker/task.py
@@ -24,9 +24,6 @@ class TaskState(Enum):
     COMPLETE = "COMPLETE"
 
 
-_COMPLETE_TASK_STATES = (TaskState.FAILED, TaskState.COMPLETE)
-
-
 # TODO: Make a TaggedUnion
 class Task(ABC):
     """

--- a/src/blueapi/worker/task.py
+++ b/src/blueapi/worker/task.py
@@ -16,14 +16,6 @@ from blueapi.core import (
 from blueapi.utils import nested_deserialize_with_overrides
 
 
-class TaskState(Enum):
-    PENDING = "PENDING"
-    RUNNING = "RUNNING"
-    PAUSED = "PAUSED"
-    FAILED = "FAILED"
-    COMPLETE = "COMPLETE"
-
-
 # TODO: Make a TaggedUnion
 class Task(ABC):
     """
@@ -96,4 +88,5 @@ def lookup_params(
 class ActiveTask:
     name: str
     task: Task
-    state: TaskState = field(default=TaskState.PENDING)
+    is_complete: bool = False
+    is_error: bool = False

--- a/src/blueapi/worker/task.py
+++ b/src/blueapi/worker/task.py
@@ -1,7 +1,6 @@
 import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from enum import Enum
 from typing import Any, Mapping, Union
 
 from apischema import deserializer, identity, serializer

--- a/src/blueapi/worker/worker.py
+++ b/src/blueapi/worker/worker.py
@@ -3,7 +3,7 @@ from typing import Generic, TypeVar
 
 from blueapi.core import DataEvent, EventStream
 
-from .event import WorkerEvent
+from .event import ProgressEvent, WorkerEvent
 
 T = TypeVar("T")
 
@@ -36,10 +36,22 @@ class Worker(ABC, Generic[T]):
     @abstractmethod
     def worker_events(self) -> EventStream[WorkerEvent, int]:
         """
-        Events representing task-agnostic changes to the worker
+        Events representing changes/errors in worker state
 
         Returns:
             EventStream[WorkerEvent, int]: Subscribable stream of events
+        """
+
+        ...
+
+    @property
+    @abstractmethod
+    def progress_events(self) -> EventStream[ProgressEvent, int]:
+        """
+        Events representing progress in running a task
+
+        Returns:
+            EventStream[ProgressEvent, int]: Subscribable stream of events
         """
 
         ...

--- a/src/blueapi/worker/worker.py
+++ b/src/blueapi/worker/worker.py
@@ -46,18 +46,6 @@ class Worker(ABC, Generic[T]):
 
     @property
     @abstractmethod
-    def task_events(self) -> EventStream[TaskEvent, int]:
-        """
-        Events representing changes to individual taks
-
-        Returns:
-            EventStream[TaskEvent, int]: Subscribable stream of events
-        """
-
-        ...
-
-    @property
-    @abstractmethod
     def data_events(self) -> EventStream[DataEvent, int]:
         """
         Events representing collection of data

--- a/src/blueapi/worker/worker.py
+++ b/src/blueapi/worker/worker.py
@@ -3,7 +3,7 @@ from typing import Generic, TypeVar
 
 from blueapi.core import DataEvent, EventStream
 
-from .event import TaskEvent, WorkerEvent
+from .event import WorkerEvent
 
 T = TypeVar("T")
 


### PR DESCRIPTION
Closes #97 

* Rationalise `WorkerEvent` and `TaskEvent` into new event types: `WorkerEvent`, and `ProgressEvent`. The former is information about the worker and tasks, the latter is information about a running plan.
* Include error messages in `WorkerEvent`
* Make worker catch all exceptions and emit them as events
