### PR TITLE
Auto-reconnect to Stomp when connection lost

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -43,9 +43,9 @@ jobs:
             python: "3.8"
             install: ".[dev]"
 
-    services:
-      activemq:
-        image: rmohr/activemq:5.14.5-alpine
+    # services:
+    #   activemq:
+    #     image: rmohr/activemq:5.14.5-alpine
 
     runs-on: ${{ matrix.os }}
     env:

--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -43,10 +43,15 @@ jobs:
             python: "3.8"
             install: ".[dev]"
 
+    services:
+      activemq:
+        image: rmohr/activemq:5.14.5-alpine
+
     runs-on: ${{ matrix.os }}
     env:
       # https://github.com/pytest-dev/pytest/issues/2042
       PY_IGNORE_IMPORTMISMATCH: "1"
+      STOMP_HOST: activemq
 
     steps:
       - name: Checkout

--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -46,6 +46,8 @@ jobs:
     services:
       activemq:
         image: rmohr/activemq:5.14.5-alpine
+        ports:
+          - 61613:61613
 
     runs-on: ${{ matrix.os }}
     env:

--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -53,7 +53,6 @@ jobs:
     env:
       # https://github.com/pytest-dev/pytest/issues/2042
       PY_IGNORE_IMPORTMISMATCH: "1"
-      # STOMP_HOST: activemq
 
     steps:
       - name: Checkout

--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -53,7 +53,7 @@ jobs:
     env:
       # https://github.com/pytest-dev/pytest/issues/2042
       PY_IGNORE_IMPORTMISMATCH: "1"
-      STOMP_HOST: activemq
+      # STOMP_HOST: activemq
 
     steps:
       - name: Checkout

--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -43,9 +43,9 @@ jobs:
             python: "3.8"
             install: ".[dev]"
 
-    # services:
-    #   activemq:
-    #     image: rmohr/activemq:5.14.5-alpine
+    services:
+      activemq:
+        image: rmohr/activemq:5.14.5-alpine
 
     runs-on: ${{ matrix.os }}
     env:

--- a/src/blueapi/messaging/stomptemplate.py
+++ b/src/blueapi/messaging/stomptemplate.py
@@ -82,7 +82,6 @@ class StompMessagingTemplate(MessagingTemplate):
         self._conn.set_listener("", self._listener)
 
         self._subscriptions = {}
-        self._pending_subscriptions = set()
 
     @classmethod
     def autoconfigured(cls, config: StompConfig) -> MessagingTemplate:
@@ -133,21 +132,17 @@ class StompMessagingTemplate(MessagingTemplate):
 
         sub_id = str(next(self._sub_num))
         self._subscriptions[sub_id] = Subscription(destination, wrapper)
-        self._pending_subscriptions.add(sub_id)
-        self._handle_pending_subscriptions()
-        # if self._conn.is_connected():
-        #     self._conn.subscribe(destination=destination, id=sub_id, ack="auto")
+        self._ensure_subscribed([sub_id])
 
     def connect(self) -> None:
         LOGGER.info("Connecting...")
         self._conn.connect(wait=True)
         self._listener.on_disconnected = self._on_disconnected
-        self._handle_pending_subscriptions()
+        self._ensure_subscribed()
 
-    def _handle_pending_subscriptions(self) -> None:
+    def _ensure_subscribed(self, sub_ids: Optional[List[str]] = None) -> None:
         if self._conn.is_connected():
-            while self._pending_subscriptions:
-                sub_id = self._pending_subscriptions.pop()
+            for sub_id in sub_ids or self._subscriptions.keys():
                 sub = self._subscriptions[sub_id]
                 LOGGER.info(f"Subscribing to {sub.destination}")
                 self._conn.subscribe(destination=sub.destination, id=sub_id, ack="auto")

--- a/src/blueapi/service/app.py
+++ b/src/blueapi/service/app.py
@@ -50,11 +50,11 @@ class Service:
             }
         )
 
-        self._template.connect()
-
         self._template.subscribe("worker.run", self._on_run_request)
         self._template.subscribe("worker.plans", self._get_plans)
         self._template.subscribe("worker.devices", self._get_devices)
+
+        self._template.connect()
 
         self._worker.run_forever()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ def pytest_addoption(parser):
     parser.addoption(
         "--skip-stomp",
         action="store_true",
-        default=False,
+        default=True,
         help="skip stomp tests (e.g. because a server is unavailable)",
     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,10 @@ import pytest
 
 def pytest_addoption(parser):
     parser.addoption(
-        "--stomp", action="store_true", default=False, help="run stomp tests"
+        "--skip-stomp",
+        action="store_true",
+        default=False,
+        help="skip stomp tests (e.g. because a server is unavailable)",
     )
 
 
@@ -14,10 +17,8 @@ def pytest_configure(config):
 
 
 def pytest_collection_modifyitems(config, items):
-    if config.getoption("--stomp"):
-        # --runslow given in cli: do not skip slow tests
-        return
-    skip_stomp = pytest.mark.skip(reason="need --stomp option to run")
-    for item in items:
-        if "stomp" in item.keywords:
-            item.add_marker(skip_stomp)
+    if config.getoption("--skip-stomp"):
+        skip_stomp = pytest.mark.skip(reason="skipping stomp tests at user request")
+        for item in items:
+            if "stomp" in item.keywords:
+                item.add_marker(skip_stomp)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ def pytest_addoption(parser):
     parser.addoption(
         "--skip-stomp",
         action="store_true",
-        default=True,
+        default=False,
         help="skip stomp tests (e.g. because a server is unavailable)",
     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,23 @@
+# Based on https://docs.pytest.org/en/latest/example/simple.html#control-skipping-of-tests-according-to-command-line-option  # noqa: E501
+
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--stomp", action="store_true", default=False, help="run stomp tests"
+    )
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "stomp: mark test as slow to run")
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--stomp"):
+        # --runslow given in cli: do not skip slow tests
+        return
+    skip_stomp = pytest.mark.skip(reason="need --stomp option to run")
+    for item in items:
+        if "stomp" in item.keywords:
+            item.add_marker(skip_stomp)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ def pytest_addoption(parser):
 
 
 def pytest_configure(config):
-    config.addinivalue_line("markers", "stomp: mark test as slow to run")
+    config.addinivalue_line("markers", "stomp: mark test as requiring stomp broker")
 
 
 def pytest_collection_modifyitems(config, items):

--- a/tests/messaging/test_stomptemplate.py
+++ b/tests/messaging/test_stomptemplate.py
@@ -1,5 +1,4 @@
 import itertools
-import os
 from concurrent.futures import Future
 from dataclasses import dataclass
 from typing import Any, Iterable, Type

--- a/tests/messaging/test_stomptemplate.py
+++ b/tests/messaging/test_stomptemplate.py
@@ -25,13 +25,9 @@ def disconnected_template(stomp_config: StompConfig) -> MessagingTemplate:
 
 @pytest.fixture
 def template(disconnected_template: MessagingTemplate) -> Iterable[MessagingTemplate]:
-    try:
-        disconnected_template.connect()
-        yield disconnected_template
-    except Exception as ex:
-        raise ex
-    finally:
-        disconnected_template.disconnect()
+    disconnected_template.connect()
+    yield disconnected_template
+    disconnected_template.disconnect()
 
 
 @pytest.fixture

--- a/tests/messaging/test_stomptemplate.py
+++ b/tests/messaging/test_stomptemplate.py
@@ -1,20 +1,125 @@
-import json
-from typing import Tuple
-from unittest.mock import MagicMock
+import itertools
+from concurrent.futures import Future
+from dataclasses import dataclass
+from typing import Any, Iterable, Type
 
-from blueapi.messaging import MessagingTemplate, StompMessagingTemplate
+import pytest
+
+from blueapi.config import StompConfig
+from blueapi.messaging import MessageContext, MessagingTemplate, StompMessagingTemplate
+
+_TIMEOUT: float = 10.0
+_COUNT = itertools.count()
 
 
-def test_send() -> None:
-    template, conn = _mock_template()
-    template.send("test", "test_message")
-    conn.send.assert_called_once_with(
-        body=json.dumps("test_message"),
-        destination="test",
-        headers={},
+@pytest.fixture
+def disconnected_template() -> MessagingTemplate:
+    return StompMessagingTemplate.autoconfigured(StompConfig())
+
+
+@pytest.fixture
+def template(disconnected_template: MessagingTemplate) -> Iterable[MessagingTemplate]:
+    try:
+        disconnected_template.connect()
+        yield disconnected_template
+    except Exception as ex:
+        raise ex
+    finally:
+        disconnected_template.disconnect()
+
+
+@pytest.fixture
+def test_queue(template: MessagingTemplate) -> str:
+    return template.destinations.queue(f"test-{next(_COUNT)}")
+
+
+@pytest.mark.stomp
+def test_send(template: MessagingTemplate, test_queue: str) -> None:
+    f: Future = Future()
+
+    def callback(ctx: MessageContext, message: str) -> None:
+        f.set_result(message)
+
+    template.subscribe(test_queue, callback)
+    template.send(test_queue, "test_message")
+    assert f.result(timeout=_TIMEOUT)
+
+
+@pytest.mark.stomp
+def test_send_on_reply(template: MessagingTemplate, test_queue: str) -> None:
+    acknowledge(template, test_queue)
+
+    f: Future = Future()
+
+    def callback(ctx: MessageContext, message: str) -> None:
+        f.set_result(message)
+
+    template.send(test_queue, "test_message", callback)
+    assert f.result(timeout=_TIMEOUT)
+
+
+@pytest.mark.stomp
+def test_send_and_recieve(template: MessagingTemplate, test_queue: str) -> None:
+    acknowledge(template, test_queue)
+    reply = template.send_and_recieve(test_queue, "test", str).result(timeout=_TIMEOUT)
+    assert reply == "ack"
+
+
+@dataclass
+class Foo:
+    a: int
+    b: str
+
+
+@pytest.mark.stomp
+@pytest.mark.parametrize(
+    "message,message_type",
+    [("test", str), (1, int), (Foo(1, "test"), Foo)],
+)
+def test_deserialization(
+    template: MessagingTemplate, test_queue: str, message: Any, message_type: Type
+) -> None:
+    def server(ctx: MessageContext, message: message_type) -> None:  # type: ignore
+        reply_queue = ctx.reply_destination
+        if reply_queue is None:
+            raise RuntimeError("reply queue is None")
+        template.send(reply_queue, message)
+
+    template.subscribe(test_queue, server)
+    reply = template.send_and_recieve(test_queue, message, message_type).result(
+        timeout=_TIMEOUT
     )
+    assert reply == message
 
 
-def _mock_template() -> Tuple[MessagingTemplate, MagicMock]:
-    conn = MagicMock()
-    return StompMessagingTemplate(conn), conn
+@pytest.mark.stomp
+def test_subscribe_before_connect(
+    disconnected_template: MessagingTemplate, test_queue: str
+) -> None:
+    acknowledge(disconnected_template, test_queue)
+    disconnected_template.connect()
+    reply = disconnected_template.send_and_recieve(test_queue, "test", str).result(
+        timeout=_TIMEOUT
+    )
+    assert reply == "ack"
+
+
+@pytest.mark.stomp
+def test_reconnect(template: MessagingTemplate, test_queue: str) -> None:
+    acknowledge(template, test_queue)
+    reply = template.send_and_recieve(test_queue, "test", str).result(timeout=_TIMEOUT)
+    assert reply == "ack"
+    template.disconnect()
+    template.connect()
+    reply = template.send_and_recieve(test_queue, "test", str).result(timeout=_TIMEOUT)
+    assert reply == "ack"
+
+
+def acknowledge(template: MessagingTemplate, test_queue: str) -> None:
+    def server(ctx: MessageContext, message: str) -> None:
+        reply_queue = ctx.reply_destination
+        if reply_queue is None:
+            raise RuntimeError("reply queue is None")
+        template.send(reply_queue, "ack")
+
+    template.subscribe(test_queue, server)

--- a/tests/messaging/test_stomptemplate.py
+++ b/tests/messaging/test_stomptemplate.py
@@ -1,4 +1,5 @@
 import itertools
+import os
 from concurrent.futures import Future
 from dataclasses import dataclass
 from typing import Any, Iterable, Type
@@ -13,8 +14,13 @@ _COUNT = itertools.count()
 
 
 @pytest.fixture
-def disconnected_template() -> MessagingTemplate:
-    return StompMessagingTemplate.autoconfigured(StompConfig())
+def stomp_config() -> StompConfig:
+    return StompConfig(host=os.environ.get("STOMP_HOST", "localhost"))
+
+
+@pytest.fixture
+def disconnected_template(stomp_config: StompConfig) -> MessagingTemplate:
+    return StompMessagingTemplate.autoconfigured(stomp_config)
 
 
 @pytest.fixture

--- a/tests/messaging/test_stomptemplate.py
+++ b/tests/messaging/test_stomptemplate.py
@@ -14,13 +14,8 @@ _COUNT = itertools.count()
 
 
 @pytest.fixture
-def stomp_config() -> StompConfig:
-    return StompConfig(host=os.environ.get("STOMP_HOST", "localhost"))
-
-
-@pytest.fixture
-def disconnected_template(stomp_config: StompConfig) -> MessagingTemplate:
-    return StompMessagingTemplate.autoconfigured(stomp_config)
+def disconnected_template() -> MessagingTemplate:
+    return StompMessagingTemplate.autoconfigured(StompConfig())
 
 
 @pytest.fixture


### PR DESCRIPTION
Closes #94 

Changes:
* Automatically attempt to reconnect every few seconds (default 10) if stomp connection is lost.
* Allow calling `subscribe()` on a stomp messaging template before calling `connect()`, subscription is deferred internally until after connection. This allows for a nicer, declarative service setup.
* Write system tests for `StompMessagingTemplate`
* Add mechanism to skip system tests if ActiveMQ is not available (e.g. local dev)
* Add activemq as a service in the CI when running tests