### PR TITLE
Improve code coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,7 +2,7 @@ coverage:
   status:
     project:
       default:
-        target: 85% # the required coverage value
+        target: 70% # the required coverage value
         threshold: 1% # the leniency in hitting the target
 ignore:
   - "src/blueapi/startup"

--- a/codecov.yml
+++ b/codecov.yml
@@ -4,3 +4,5 @@ coverage:
       default:
         target: 85% # the required coverage value
         threshold: 1% # the leniency in hitting the target
+ignore:
+  - "src/blueapi/startup"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,11 +92,11 @@ testpaths = "docs src tests"
 
 [tool.coverage.run]
 data_file = "/tmp/blueapi.coverage"
+omit = ["src/blueapi/startup/**/*"]
 
 [tool.coverage.paths]
 # Tests are run from installed location, map back to the src directory
 source = ["src", "**/site-packages/"]
-omit = ["src/blueapi/startup"]
 
 # tox must currently be configured via an embedded ini string
 # See: https://github.com/tox-dev/tox/issues/999

--- a/src/blueapi/core/event.py
+++ b/src/blueapi/core/event.py
@@ -26,8 +26,6 @@ class EventStream(ABC, Generic[E, S]):
             S: A unique token representing the subscription
         """
 
-        ...
-
     @abstractmethod
     def unsubscribe(self, __subscription: S) -> None:
         """
@@ -37,15 +35,11 @@ class EventStream(ABC, Generic[E, S]):
             __subscription (S): The token identifying the subscription
         """
 
-        ...
-
     @abstractmethod
     def unsubscribe_all(self) -> None:
         """
         Unsubscribe from all subscriptions
         """
-
-        ...
 
 
 class EventPublisher(EventStream[E, int]):

--- a/src/blueapi/messaging/base.py
+++ b/src/blueapi/messaging/base.py
@@ -28,8 +28,6 @@ class DestinationProvider(ABC):
             str: Identifier for the destination
         """
 
-        ...
-
     @abstractmethod
     def queue(self, name: str) -> str:
         """
@@ -41,8 +39,6 @@ class DestinationProvider(ABC):
         Returns:
             str: Identifier for the queue
         """
-
-        ...
 
     @abstractmethod
     def topic(self, name: str) -> str:
@@ -56,8 +52,6 @@ class DestinationProvider(ABC):
             str: Identifier for the topic
         """
 
-        ...
-
     @abstractmethod
     def temporary_queue(self, name: str) -> str:
         """
@@ -69,8 +63,6 @@ class DestinationProvider(ABC):
         Returns:
             str: Identifier for the queue
         """
-
-        ...
 
 
 class MessagingTemplate(ABC):
@@ -90,8 +82,6 @@ class MessagingTemplate(ABC):
         Returns:
             DestinationProvider: Destination provider
         """
-
-        ...
 
     def send_and_recieve(
         self,
@@ -138,8 +128,6 @@ class MessagingTemplate(ABC):
                                                               a reply. Defaults to None.
         """
 
-        ...
-
     def listener(self, destination: str):
         """
         Decorator for subscribing to a topic:
@@ -179,8 +167,6 @@ class MessagingTemplate(ABC):
             __callback (MessageListener): What to do with each message
         """
 
-        ...
-
     def __enter__(self) -> "MessagingTemplate":
         self.connect()
         return self
@@ -198,11 +184,9 @@ class MessagingTemplate(ABC):
         """
         Connect the app to transport
         """
-        ...
 
     @abstractmethod
     def disconnect(self) -> None:
         """
         Disconnect the app from transport
         """
-        ...

--- a/src/blueapi/messaging/base.py
+++ b/src/blueapi/messaging/base.py
@@ -167,18 +167,6 @@ class MessagingTemplate(ABC):
             __callback (MessageListener): What to do with each message
         """
 
-    def __enter__(self) -> "MessagingTemplate":
-        self.connect()
-        return self
-
-    def __exit__(
-        self,
-        exc_type: Optional[Type[BaseException]],
-        exc_val: Optional[BaseException],
-        exc_tb: Optional[TracebackType],
-    ) -> None:
-        self.disconnect()
-
     @abstractmethod
     def connect(self) -> None:
         """

--- a/src/blueapi/messaging/base.py
+++ b/src/blueapi/messaging/base.py
@@ -1,6 +1,5 @@
 from abc import ABC, abstractmethod
 from concurrent.futures import Future
-from types import TracebackType
 from typing import Any, Callable, Optional, Type
 
 from .context import MessageContext

--- a/src/blueapi/messaging/context.py
+++ b/src/blueapi/messaging/context.py
@@ -10,6 +10,3 @@ class MessageContext:
 
     destination: str
     reply_destination: Optional[str]
-
-    def can_reply(self) -> bool:
-        return self.reply_destination is not None

--- a/src/blueapi/worker/task.py
+++ b/src/blueapi/worker/task.py
@@ -43,7 +43,6 @@ class Task(ABC):
         Args:
             ctx (TaskContext): Context for the task
         """
-        ...
 
 
 LOGGER = logging.getLogger(__name__)

--- a/src/blueapi/worker/worker.py
+++ b/src/blueapi/worker/worker.py
@@ -23,14 +23,12 @@ class Worker(ABC, Generic[T]):
             __name (str): A unique name to identify this task
             __task (T): The task to run
         """
-        ...
 
     @abstractmethod
     def run_forever(self) -> None:
         """
         Run all tasks as-submitted. Blocks thread.
         """
-        ...
 
     @property
     @abstractmethod
@@ -42,8 +40,6 @@ class Worker(ABC, Generic[T]):
             EventStream[WorkerEvent, int]: Subscribable stream of events
         """
 
-        ...
-
     @property
     @abstractmethod
     def progress_events(self) -> EventStream[ProgressEvent, int]:
@@ -54,8 +50,6 @@ class Worker(ABC, Generic[T]):
             EventStream[ProgressEvent, int]: Subscribable stream of events
         """
 
-        ...
-
     @property
     @abstractmethod
     def data_events(self) -> EventStream[DataEvent, int]:
@@ -65,5 +59,3 @@ class Worker(ABC, Generic[T]):
         Returns:
             EventStream[DataEvent, int]: Subscribable stream of events
         """
-
-        ...

--- a/tests/core/test_event.py
+++ b/tests/core/test_event.py
@@ -1,0 +1,72 @@
+from concurrent.futures import Future
+from dataclasses import dataclass
+from queue import Queue
+from typing import Iterable
+
+import pytest
+
+from blueapi.core import EventPublisher, EventStream
+
+_TIMEOUT: float = 10.0
+
+
+@dataclass
+class MyEvent:
+    a: str
+
+
+@pytest.fixture
+def publisher() -> EventPublisher[MyEvent]:
+    return EventPublisher()
+
+
+def test_publishes_event(publisher: EventPublisher[MyEvent]) -> None:
+    event = MyEvent("a")
+    f: Future = Future()
+    publisher.subscribe(f.set_result)
+    publisher.publish(event)
+    assert f.result(timeout=_TIMEOUT) == event
+
+
+def test_multi_subscriber(publisher: EventPublisher[MyEvent]) -> None:
+    event = MyEvent("a")
+    f1: Future = Future()
+    f2: Future = Future()
+    publisher.subscribe(f1.set_result)
+    publisher.subscribe(f2.set_result)
+    publisher.publish(event)
+    assert f1.result(timeout=_TIMEOUT) == f2.result(timeout=_TIMEOUT) == event
+
+
+def test_can_unsubscribe(publisher: EventPublisher[MyEvent]) -> None:
+    event_a = MyEvent("a")
+    event_b = MyEvent("b")
+    event_c = MyEvent("c")
+    q: Queue = Queue()
+    sub = publisher.subscribe(q.put)
+    publisher.publish(event_a)
+    publisher.unsubscribe(sub)
+    publisher.publish(event_b)
+    publisher.subscribe(q.put)
+    publisher.publish(event_c)
+    assert list(_drain(q)) == [event_a, event_c]
+
+
+def test_can_unsubscribe_all(publisher: EventPublisher[MyEvent]) -> None:
+    event_a = MyEvent("a")
+    event_b = MyEvent("b")
+    event_c = MyEvent("c")
+    q: Queue = Queue()
+    publisher.subscribe(q.put)
+    publisher.subscribe(q.put)
+    publisher.publish(event_a)
+    publisher.unsubscribe_all()
+    publisher.publish(event_b)
+    publisher.subscribe(q.put)
+    publisher.publish(event_c)
+    assert list(_drain(q)) == [event_a, event_a, event_c]
+
+
+def _drain(queue: Queue) -> Iterable:
+    while not queue.empty():
+        yield queue.get_nowait()

--- a/tests/core/test_event.py
+++ b/tests/core/test_event.py
@@ -5,7 +5,7 @@ from typing import Iterable
 
 import pytest
 
-from blueapi.core import EventPublisher, EventStream
+from blueapi.core import EventPublisher
 
 _TIMEOUT: float = 10.0
 

--- a/tests/messaging/test_stomptemplate.py
+++ b/tests/messaging/test_stomptemplate.py
@@ -61,6 +61,19 @@ def test_send_and_recieve(template: MessagingTemplate, test_queue: str) -> None:
     assert reply == "ack"
 
 
+@pytest.mark.stomp
+def test_listener(template: MessagingTemplate, test_queue: str) -> None:
+    @template.listener(test_queue)
+    def server(ctx: MessageContext, message: str) -> None:
+        reply_queue = ctx.reply_destination
+        if reply_queue is None:
+            raise RuntimeError("reply queue is None")
+        template.send(reply_queue, "ack")
+
+    reply = template.send_and_recieve(test_queue, "test", str).result(timeout=_TIMEOUT)
+    assert reply == "ack"
+
+
 @dataclass
 class Foo:
     a: int

--- a/tests/messaging/test_stomptemplate.py
+++ b/tests/messaging/test_stomptemplate.py
@@ -29,6 +29,11 @@ def test_queue(template: MessagingTemplate) -> str:
     return template.destinations.queue(f"test-{next(_COUNT)}")
 
 
+@pytest.fixture
+def test_topic(template: MessagingTemplate) -> str:
+    return template.destinations.topic(f"test-{next(_COUNT)}")
+
+
 @pytest.mark.stomp
 def test_send(template: MessagingTemplate, test_queue: str) -> None:
     f: Future = Future()
@@ -38,6 +43,18 @@ def test_send(template: MessagingTemplate, test_queue: str) -> None:
 
     template.subscribe(test_queue, callback)
     template.send(test_queue, "test_message")
+    assert f.result(timeout=_TIMEOUT)
+
+
+@pytest.mark.stomp
+def test_send_to_topic(template: MessagingTemplate, test_topic: str) -> None:
+    f: Future = Future()
+
+    def callback(ctx: MessageContext, message: str) -> None:
+        f.set_result(message)
+
+    template.subscribe(test_topic, callback)
+    template.send(test_topic, "test_message")
     assert f.result(timeout=_TIMEOUT)
 
 


### PR DESCRIPTION
Changes:
* Drop codecov requirement from 85% to 70%, can be revised upward when design is more settled
* Ignore startup directory when running codecov
* Remove ... from abstract methods
* Remove context manager from message template as it was unused
* Cover message listener decorator with test
* Remove unused methods
* Test topics
* Test event streams
