### PR TITLE
Use Correlation ID

### DIFF
--- a/src/blueapi/messaging/base.py
+++ b/src/blueapi/messaging/base.py
@@ -87,6 +87,7 @@ class MessagingTemplate(ABC):
         destination: str,
         obj: Any,
         reply_type: Type = str,
+        correlation_id: Optional[str] = None,
     ) -> Future:
         """
         Send a message expecting a single reply.
@@ -107,7 +108,7 @@ class MessagingTemplate(ABC):
             future.set_result(reply)
 
         callback.__annotations__["reply"] = reply_type
-        self.send(destination, obj, callback)
+        self.send(destination, obj, callback, correlation_id)
         return future
 
     @abstractmethod
@@ -116,6 +117,7 @@ class MessagingTemplate(ABC):
         __destination: str,
         __obj: Any,
         __on_reply: Optional[MessageListener] = None,
+        __correlation_id: Optional[str] = None,
     ) -> None:
         """
         Send a message to a destination

--- a/src/blueapi/messaging/context.py
+++ b/src/blueapi/messaging/context.py
@@ -10,3 +10,4 @@ class MessageContext:
 
     destination: str
     reply_destination: Optional[str]
+    correlation_id: Optional[str]

--- a/src/blueapi/messaging/stomptemplate.py
+++ b/src/blueapi/messaging/stomptemplate.py
@@ -21,7 +21,7 @@ from .utils import determine_deserialization_type
 
 LOGGER = logging.getLogger(__name__)
 
-CORRELATION_ID_HEADER = "JMSCorrelationID"
+CORRELATION_ID_HEADER = "correlation-id"
 
 
 class StompDestinationProvider(DestinationProvider):

--- a/src/blueapi/worker/task.py
+++ b/src/blueapi/worker/task.py
@@ -36,12 +36,12 @@ class Task(ABC):
         )
 
     @abstractmethod
-    def do_task(self, ctx: BlueskyContext) -> None:
+    def do_task(self, __ctx: BlueskyContext) -> None:
         """
         Perform the task using the context
 
         Args:
-            ctx (TaskContext): Context for the task
+            ctx: Context for the task, holds plans/device/etc
         """
 
 

--- a/tests/core/test_event.py
+++ b/tests/core/test_event.py
@@ -23,7 +23,7 @@ def publisher() -> EventPublisher[MyEvent]:
 def test_publishes_event(publisher: EventPublisher[MyEvent]) -> None:
     event = MyEvent("a")
     f: Future = Future()
-    publisher.subscribe(f.set_result)
+    publisher.subscribe(lambda r, _: f.set_result(r))
     publisher.publish(event)
     assert f.result(timeout=_TIMEOUT) == event
 
@@ -32,8 +32,8 @@ def test_multi_subscriber(publisher: EventPublisher[MyEvent]) -> None:
     event = MyEvent("a")
     f1: Future = Future()
     f2: Future = Future()
-    publisher.subscribe(f1.set_result)
-    publisher.subscribe(f2.set_result)
+    publisher.subscribe(lambda r, _: f1.set_result(r))
+    publisher.subscribe(lambda r, _: f2.set_result(r))
     publisher.publish(event)
     assert f1.result(timeout=_TIMEOUT) == f2.result(timeout=_TIMEOUT) == event
 
@@ -43,11 +43,11 @@ def test_can_unsubscribe(publisher: EventPublisher[MyEvent]) -> None:
     event_b = MyEvent("b")
     event_c = MyEvent("c")
     q: Queue = Queue()
-    sub = publisher.subscribe(q.put)
+    sub = publisher.subscribe(lambda r, _: q.put(r))
     publisher.publish(event_a)
     publisher.unsubscribe(sub)
     publisher.publish(event_b)
-    publisher.subscribe(q.put)
+    publisher.subscribe(lambda r, _: q.put(r))
     publisher.publish(event_c)
     assert list(_drain(q)) == [event_a, event_c]
 
@@ -57,14 +57,23 @@ def test_can_unsubscribe_all(publisher: EventPublisher[MyEvent]) -> None:
     event_b = MyEvent("b")
     event_c = MyEvent("c")
     q: Queue = Queue()
-    publisher.subscribe(q.put)
-    publisher.subscribe(q.put)
+    publisher.subscribe(lambda r, _: q.put(r))
+    publisher.subscribe(lambda r, _: q.put(r))
     publisher.publish(event_a)
     publisher.unsubscribe_all()
     publisher.publish(event_b)
-    publisher.subscribe(q.put)
+    publisher.subscribe(lambda r, _: q.put(r))
     publisher.publish(event_c)
     assert list(_drain(q)) == [event_a, event_a, event_c]
+
+
+def test_correlation_id(publisher: EventPublisher[MyEvent]) -> None:
+    event = MyEvent("a")
+    correlation_id = "foobar"
+    f: Future = Future()
+    publisher.subscribe(lambda _, c: f.set_result(c))
+    publisher.publish(event, correlation_id)
+    assert f.result(timeout=_TIMEOUT) == correlation_id
 
 
 def _drain(queue: Queue) -> Iterable:


### PR DESCRIPTION
Changes:
* Optionally allow correlation IDs to be propagated through internal events
* Add optional correlation ID to context of received messages, derived from `correlation-id` header in stomp frame
* Add optional correlation ID argument to send message method
* Add tests for the above
* Propagate correlation ID through worker events
* Use correlation ID for plan requests or generate a new one if not present
