### PR TITLE
Make all API models convert to camelCase

### DIFF
--- a/src/blueapi/config.py
+++ b/src/blueapi/config.py
@@ -1,10 +1,12 @@
 from pathlib import Path
 from typing import Union
 
-from pydantic import BaseModel, Field
+from pydantic import Field
+
+from blueapi.utils import BlueapiBaseModel
 
 
-class StompConfig(BaseModel):
+class StompConfig(BlueapiBaseModel):
     """
     Config for connecting to stomp broker
     """
@@ -13,7 +15,7 @@ class StompConfig(BaseModel):
     port: int = 61613
 
 
-class EnvironmentConfig(BaseModel):
+class EnvironmentConfig(BlueapiBaseModel):
     """
     Config for the RunEngine environment
     """
@@ -21,11 +23,11 @@ class EnvironmentConfig(BaseModel):
     startup_script: Union[Path, str] = "blueapi.startup.example"
 
 
-class LoggingConfig(BaseModel):
+class LoggingConfig(BlueapiBaseModel):
     level: str = "INFO"
 
 
-class ApplicationConfig(BaseModel):
+class ApplicationConfig(BlueapiBaseModel):
     """
     Config for the worker application as a whole. Root of
     config tree.

--- a/src/blueapi/core/bluesky_types.py
+++ b/src/blueapi/core/bluesky_types.py
@@ -21,6 +21,8 @@ from bluesky.protocols import (
 from bluesky.utils import Msg
 from pydantic import BaseModel, Field
 
+from blueapi.utils import BlueapiBaseModel
+
 try:
     from typing import Protocol, runtime_checkable
 except ImportError:
@@ -79,7 +81,7 @@ def is_bluesky_plan_generator(func: PlanGenerator) -> bool:
     )
 
 
-class Plan(BaseModel):
+class Plan(BlueapiBaseModel):
     """
     A plan that can be run
     """
@@ -90,7 +92,7 @@ class Plan(BaseModel):
     )
 
 
-class DataEvent(BaseModel):
+class DataEvent(BlueapiBaseModel):
     """
     Event representing collection of some data. Conforms to the Bluesky event model:
     https://github.com/bluesky/event-model

--- a/src/blueapi/core/context.py
+++ b/src/blueapi/core/context.py
@@ -7,7 +7,6 @@ from typing import Dict, Iterable, List, Optional, Union
 
 from bluesky import RunEngine
 from bluesky.protocols import Flyable, Readable
-from pydantic import BaseConfig
 
 from blueapi.utils import (
     BlueapiPlanModelConfig,

--- a/src/blueapi/core/context.py
+++ b/src/blueapi/core/context.py
@@ -10,6 +10,7 @@ from bluesky.protocols import Flyable, Readable
 from pydantic import BaseConfig
 
 from blueapi.utils import (
+    BlueapiPlanModelConfig,
     TypeValidatorDefinition,
     create_model_with_type_validators,
     load_module_all,
@@ -26,10 +27,6 @@ from .bluesky_types import (
 from .device_lookup import find_component
 
 LOGGER = logging.getLogger(__name__)
-
-
-class PlanModelConfig(BaseConfig):
-    arbitrary_types_allowed = True
 
 
 @dataclass
@@ -122,7 +119,7 @@ class BlueskyContext:
             plan.__name__,
             validators,
             func=plan,
-            config=PlanModelConfig,
+            config=BlueapiPlanModelConfig,
         )
         self.plans[plan.__name__] = Plan(name=plan.__name__, model=model)
         self.plan_functions[plan.__name__] = plan

--- a/src/blueapi/service/model.py
+++ b/src/blueapi/service/model.py
@@ -1,14 +1,15 @@
 from typing import Iterable, List
 
 from bluesky.protocols import HasName
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 from blueapi.core import BLUESKY_PROTOCOLS, Device, Plan
+from blueapi.utils import BlueapiBaseModel
 
 _UNKNOWN_NAME = "UNKNOWN"
 
 
-class DeviceModel(BaseModel):
+class DeviceModel(BlueapiBaseModel):
     """
     Representation of a device
     """
@@ -30,7 +31,7 @@ def _protocol_names(device: Device) -> Iterable[str]:
             yield protocol.__name__
 
 
-class DeviceRequest(BaseModel):
+class DeviceRequest(BlueapiBaseModel):
     """
     A query for devices
     """
@@ -38,7 +39,7 @@ class DeviceRequest(BaseModel):
     ...
 
 
-class DeviceResponse(BaseModel):
+class DeviceResponse(BlueapiBaseModel):
     """
     Response to a query for devices
     """
@@ -46,7 +47,7 @@ class DeviceResponse(BaseModel):
     devices: List[DeviceModel] = Field(description="Devices available to use in plans")
 
 
-class PlanModel(BaseModel):
+class PlanModel(BlueapiBaseModel):
     """
     Representation of a plan
     """
@@ -58,7 +59,7 @@ class PlanModel(BaseModel):
         return cls(name=plan.name)
 
 
-class PlanRequest(BaseModel):
+class PlanRequest(BlueapiBaseModel):
     """
     A query for plans
     """
@@ -66,7 +67,7 @@ class PlanRequest(BaseModel):
     ...
 
 
-class PlanResponse(BaseModel):
+class PlanResponse(BlueapiBaseModel):
     """
     Response to a query for plans
     """
@@ -74,7 +75,7 @@ class PlanResponse(BaseModel):
     plans: List[PlanModel] = Field(description="Plans available to use by a worker")
 
 
-class TaskResponse(BaseModel):
+class TaskResponse(BlueapiBaseModel):
     """
     Acknowledgement that a task has started, includes its ID
     """

--- a/src/blueapi/utils/__init__.py
+++ b/src/blueapi/utils/__init__.py
@@ -1,3 +1,4 @@
+from .base_model import BlueapiBaseModel, BlueapiModelConfig, BlueapiPlanModelConfig
 from .config import ConfigLoader
 from .modules import load_module_all
 from .serialization import serialize
@@ -11,4 +12,7 @@ __all__ = [
     "create_model_with_type_validators",
     "TypeValidatorDefinition",
     "serialize",
+    "BlueapiBaseModel",
+    "BlueapiModelConfig",
+    "BlueapiPlanModelConfig",
 ]

--- a/src/blueapi/utils/base_model.py
+++ b/src/blueapi/utils/base_model.py
@@ -1,0 +1,35 @@
+from pydantic import BaseConfig, BaseModel, Extra
+
+
+def _to_camel(string: str) -> str:
+    words = string.split("_")
+    return words[0] + "".join(word.capitalize() for word in words[1:])
+
+
+class BlueapiModelConfig(BaseConfig):
+    """
+    Pydantic config for blueapi API models with
+    common config.
+    """
+
+    alias_generator = _to_camel
+    extra = Extra.forbid
+
+
+class BlueapiPlanModelConfig(BlueapiModelConfig):
+    """
+    Pydantic config for plan parameters.
+    Includes arbitrary type config so that devices
+    can be parameters.
+    """
+
+    arbitrary_types_allowed = True
+
+
+class BlueapiBaseModel(BaseModel):
+    """
+    Base class for blueapi API models.
+    Includes common config.
+    """
+
+    Config = BlueapiModelConfig

--- a/src/blueapi/utils/base_model.py
+++ b/src/blueapi/utils/base_model.py
@@ -30,6 +30,20 @@ class BlueapiBaseModel(BaseModel):
     """
     Base class for blueapi API models.
     Includes common config.
+
+    Previously, with apischema, the API models
+    were serialized with camel case aliasing.
+    For example, converting a Python field
+    called foo_bar to a JSON field called fooBar
+    and vice versa. This is to comply with the
+    Google JSON style guide.
+    https://google.github.io/styleguide/jsoncstyleguide.xml?showone=Property_Name_Format#Property_Name_Format
+
+    We have a custom base model with custom config
+    primarily to preserve this change and also
+    to prevent the ingestion of arbirtrary JSON
+    alongside a model's known fields, which
+    apischema also did not allow.
     """
 
     Config = BlueapiModelConfig

--- a/src/blueapi/worker/event.py
+++ b/src/blueapi/worker/event.py
@@ -2,8 +2,10 @@ from enum import Enum
 from typing import List, Mapping, Optional, Union
 
 from bluesky.run_engine import RunEngineStateMachine
-from pydantic import BaseModel, Field
+from pydantic import Field
 from super_state_machine.extras import PropertyMachine, ProxyString
+
+from blueapi.utils import BlueapiBaseModel
 
 # The RunEngine can return any of these three types as its state
 RawRunEngineState = Union[PropertyMachine, ProxyString, str]
@@ -41,7 +43,7 @@ class WorkerState(str, Enum):
         return WorkerState(str(bluesky_state).upper())
 
 
-class StatusView(BaseModel):
+class StatusView(BlueapiBaseModel):
     """
     A snapshot of a Status of an operation, optionally representing progress
     """
@@ -80,7 +82,7 @@ class StatusView(BaseModel):
     )
 
 
-class ProgressEvent(BaseModel):
+class ProgressEvent(BlueapiBaseModel):
     """
     Event describing the progress of processes within a running task,
     such as moving motors and exposing detectors.
@@ -90,7 +92,7 @@ class ProgressEvent(BaseModel):
     statuses: Mapping[str, StatusView] = Field(default_factory=dict)
 
 
-class TaskStatus(BaseModel):
+class TaskStatus(BlueapiBaseModel):
     """
     Status of a task the worker is running.
     """
@@ -100,7 +102,7 @@ class TaskStatus(BaseModel):
     task_failed: bool
 
 
-class WorkerEvent(BaseModel):
+class WorkerEvent(BlueapiBaseModel):
     """
     Event describing the state of the worker and any tasks it's running.
     Includes error and warning information.

--- a/src/blueapi/worker/task.py
+++ b/src/blueapi/worker/task.py
@@ -3,13 +3,14 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Any, Mapping
 
-from pydantic import BaseModel, Field, parse_obj_as
+from pydantic import Field, parse_obj_as
 
 from blueapi.core import BlueskyContext, Plan
+from blueapi.utils import BlueapiBaseModel
 
 
 # TODO: Make a TaggedUnion
-class Task(ABC, BaseModel):
+class Task(ABC, BlueapiBaseModel):
     """
     Object that can run with a TaskContext
     """
@@ -49,7 +50,7 @@ class RunPlan(Task):
 
 def _lookup_params(
     ctx: BlueskyContext, plan: Plan, params: Mapping[str, Any]
-) -> BaseModel:
+) -> BlueapiBaseModel:
     """
     Checks plan parameters against context
 

--- a/src/blueapi/worker/task.py
+++ b/src/blueapi/worker/task.py
@@ -3,7 +3,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Any, Mapping
 
-from pydantic import Field, parse_obj_as
+from pydantic import BaseModel, Field, parse_obj_as
 
 from blueapi.core import BlueskyContext, Plan
 from blueapi.utils import BlueapiBaseModel
@@ -50,7 +50,7 @@ class RunPlan(Task):
 
 def _lookup_params(
     ctx: BlueskyContext, plan: Plan, params: Mapping[str, Any]
-) -> BlueapiBaseModel:
+) -> BaseModel:
     """
     Checks plan parameters against context
 


### PR DESCRIPTION
Previously, with apischema, the API models were serialized with camel case aliasing. For example, converting a Python field called `foo_bar` to a JSON field called `fooBar` and vice versa. This is to comply with the Google JSON style guide. 

https://google.github.io/styleguide/jsoncstyleguide.xml?showone=Property_Name_Format#Property_Name_Format 

This PR adds a custom base model with custom config primarily to preserve this change and also to prevent the ingestion of arbitrary JSON alongside a model's known fields, which apischema also did not allow.