### PR TITLE
Fix issues with serialization and GDA compatibility

### DIFF
--- a/src/blueapi/utils/base_model.py
+++ b/src/blueapi/utils/base_model.py
@@ -14,6 +14,7 @@ class BlueapiModelConfig(BaseConfig):
 
     alias_generator = _to_camel
     extra = Extra.forbid
+    allow_population_by_field_name = True
 
 
 class BlueapiPlanModelConfig(BlueapiModelConfig):

--- a/src/blueapi/utils/serialization.py
+++ b/src/blueapi/utils/serialization.py
@@ -17,7 +17,9 @@ def serialize(obj: Any) -> Any:
     """
 
     if isinstance(obj, BaseModel):
-        return obj.dict()
+        # Serialize by alias so that our camelCase models leave the service
+        # with camelCase field names
+        return obj.dict(by_alias=True)
     elif hasattr(obj, "__pydantic_model__"):
         return serialize(getattr(obj, "__pydantic_model__"))
     else:

--- a/tests/utils/test_base_model.py
+++ b/tests/utils/test_base_model.py
@@ -1,0 +1,25 @@
+from blueapi.utils import BlueapiBaseModel
+
+
+class FooBar(BlueapiBaseModel):
+    hello: str = "hello"
+    hello_world: str = "hello world"
+
+
+def test_snake_case_constructor() -> None:
+    FooBar(
+        hello="hello",
+        hello_world="hello world",
+    )
+
+
+def test_camel_case_parsing() -> None:
+    assert FooBar.parse_obj(
+        {
+            "hello": "hello",
+            "helloWorld": "hello world",
+        }
+    ) == FooBar(
+        hello="hello",
+        hello_world="hello world",
+    )


### PR DESCRIPTION
Changes:
* Change default pydantic config so that documents can be deserialized from JSON with camelCase fields but constructed in Python with snake_case fields.
* Add tests to catch if this config ever breaks
* Serialize models with aliases in messaging