### PR TITLE
Fix type validators to work with future versions of type hints

### DIFF
--- a/src/blueapi/utils/type_validator.py
+++ b/src/blueapi/utils/type_validator.py
@@ -261,9 +261,9 @@ def _extract_fields_from_function(func: Callable[..., Any]) -> Fields:
     # https://stackoverflow.com/questions/66734640/any-downsides-to-using-from-future-import-annotations-everywhere
     type_hints = get_type_hints(func)
     for name, param in signature(func).parameters.items():
-        type_annotation = type_hints[name]
-        if type_annotation is Parameter.empty:
+        if name not in type_hints:
             raise TypeError(f"Missing type annotation for parameter {name}")
+        type_annotation = type_hints[name]
         default_value = param.default
         if default_value is Parameter.empty:
             default_value = Undefined

--- a/src/blueapi/utils/type_validator.py
+++ b/src/blueapi/utils/type_validator.py
@@ -17,6 +17,7 @@ from typing import (
     TypeVar,
     Union,
     get_args,
+    get_type_hints,
     overload,
 )
 
@@ -175,9 +176,10 @@ def create_model_with_type_validators(
         all_fields[name] = apply_type_validators(annotation, definitions), val
 
     validators = _type_validators(all_fields, definitions)
-    return create_model(  # type: ignore
+    model = create_model(  # type: ignore
         name, **all_fields, __base__=base, __validators__=validators, __config__=config
     )
+    return model
 
 
 def apply_type_validators(
@@ -254,8 +256,12 @@ def _extract_fields_from_model(model: Type[BaseModel]) -> Fields:
 
 def _extract_fields_from_function(func: Callable[..., Any]) -> Fields:
     fields: Dict[str, FieldDefinition] = {}
+    # We must use get_type_hints to evaluate annotations due to
+    # PEP 563, see link:
+    # https://stackoverflow.com/questions/66734640/any-downsides-to-using-from-future-import-annotations-everywhere
+    type_hints = get_type_hints(func)
     for name, param in signature(func).parameters.items():
-        type_annotation = param.annotation
+        type_annotation = type_hints[name]
         if type_annotation is Parameter.empty:
             raise TypeError(f"Missing type annotation for parameter {name}")
         default_value = param.default

--- a/tests/utils/test_type_validator.py
+++ b/tests/utils/test_type_validator.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any, Dict, List, Literal, Mapping, Optional, Set, Tuple, Type, Union
 
 import pytest

--- a/tests/utils/test_type_validator.py
+++ b/tests/utils/test_type_validator.py
@@ -101,6 +101,10 @@ def baz(bar: Bar) -> None:
     ...
 
 
+def no_hints(a, b) -> None:
+    ...
+
+
 _DB: Mapping[str, ComplexObject] = {name: ComplexObject(name) for name in _REG.keys()}
 
 
@@ -503,6 +507,15 @@ def test_model_from_simple_function_signature() -> None:
     parsed = parse_obj_as(model, {"a": "g", "b": "hello"})
     assert parsed.a == 6  # type: ignore
     assert parsed.b == "hello"  # type: ignore
+
+
+def test_does_not_allow_parameters_without_type_hints() -> None:
+    with pytest.raises(TypeError):
+        create_model_with_type_validators(
+            "Foo",
+            [TypeValidatorDefinition(int, lookup)],
+            func=no_hints,
+        )
 
 
 def test_model_from_complex_function_signature() -> None:


### PR DESCRIPTION
Several tests broke when using 
```python
from __future__ import annotations
```
Because in the future type annotations will be more lazily. We must use a specific function, `typing.get_type_hints` to properly evaluate them.
This is annoying as we still need to use `signature().parameters` to get the default values, but I could not find a better way.

This PR adds the future import to the tests and invokes the requires function.