### PR TITLE
Make BlueskyContext accept all objects with a name property as devices

### DIFF
--- a/src/blueapi/core/context.py
+++ b/src/blueapi/core/context.py
@@ -6,7 +6,6 @@ from types import ModuleType
 from typing import Dict, Iterable, List, Optional, Union
 
 from bluesky import RunEngine
-from bluesky.protocols import Flyable, Readable
 
 from blueapi.utils import (
     BlueapiPlanModelConfig,
@@ -18,6 +17,7 @@ from blueapi.utils import (
 from .bluesky_types import (
     BLUESKY_PROTOCOLS,
     Device,
+    HasName,
     Plan,
     PlanGenerator,
     is_bluesky_compatible_device,
@@ -144,7 +144,7 @@ class BlueskyContext:
             raise TypeError(f"{device} is not a Bluesky compatible device")
 
         if name is None:
-            if isinstance(device, Readable) or isinstance(device, Flyable):
+            if isinstance(device, HasName):
                 name = device.name
             else:
                 raise KeyError(f"Must supply a name for this device: {device}")


### PR DESCRIPTION
Previously, BlueskyContext only accepted objects that conformed to the `Readable` or `Flyable` protocols  as devices. This is inherited from the days when all devices conformed to these protocols or their inheritors. Now the protocols no longer have an inheritance heirachy and are mixed and matched through multiple inheritance. The only sensible criteria is whether an object has a `name` property. This opens the door to abuse, storing objects that are definitely not devices, but that may be the price to pay for the required flexibility.