### PR TITLE
Rename CLI to blueapi and deprecate old one

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -33,5 +33,5 @@ COPY --from=build /venv/ /venv/
 ENV PATH=/venv/bin:$PATH
 
 # change this entrypoint if it is not the same as the repo
-ENTRYPOINT ["bluesky"]
+ENTRYPOINT ["blueapi"]
 CMD ["worker"]

--- a/docs/developer/tutorials/dev-run.rst
+++ b/docs/developer/tutorials/dev-run.rst
@@ -44,7 +44,7 @@ Start the worker from the command line or vscode:
 
         .. code:: shell
 
-            bluesky worker
+            blueapi worker
 
     .. tab-item:: VSCode
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,8 @@ dev = [
 ]
 
 [project.scripts]
-bluesky = "blueapi.cli:main"
+blueapi = "blueapi.cli:main"
+bluesky = "blueapi.cli._deprecated:main"
 
 [project.urls]
 GitHub = "https://github.com/DiamondLightSource/blueapi"

--- a/src/blueapi/cli/_deprecated.py
+++ b/src/blueapi/cli/_deprecated.py
@@ -1,0 +1,11 @@
+from .cli import main
+
+__all__ = ["main"]
+
+DEPRECATION_MESSAGE = (
+    "WARNING! This command is deprecated, please use >>blueapi instead!"
+)
+
+print("*" * len(DEPRECATION_MESSAGE))
+print(DEPRECATION_MESSAGE)
+print("*" * len(DEPRECATION_MESSAGE))


### PR DESCRIPTION
From discussion with @joeshannon, it's probably best if the old CLI command `bluesky` goes away to be replaced with `blueapi` to avoid confusion. 