### PR TITLE
Rationalise docs structure

### DIFF
--- a/docs/developer/index.rst
+++ b/docs/developer/index.rst
@@ -4,6 +4,8 @@ Developer Guide
 Documentation is split into four categories, also accessible from links in the
 side-bar.
 
+.. note:: Assumes you have read the `../user/index`
+
 .. grid:: 2
     :gutter: 4
 
@@ -64,14 +66,3 @@ side-bar.
         +++
 
         Technical reference material on standards in use.
-
-    .. grid-item-card:: :material-regular:`menu_book;3em`
-
-        .. toctree::
-            :caption: APIs
-            :maxdepth: 1
-
-            ../../user/reference/api
-            ../../user/reference/asyncapi
-
-        +++    

--- a/docs/user/index.rst
+++ b/docs/user/index.rst
@@ -50,19 +50,9 @@ side-bar.
             :maxdepth: 1
 
             reference/api
+            reference/asyncapi
             ../genindex
 
         +++
 
         Technical reference material including APIs and release notes.
-
-    .. grid-item-card:: :material-regular:`menu_book;3em`
-
-        .. toctree::
-            :caption: APIs
-            :maxdepth: 1
-
-            reference/api
-            reference/asyncapi
-
-        +++        


### PR DESCRIPTION
* Remove `APIs` sections in toctrees and put them under `Reference`.
* Remove duplicate links in user and developer toctrees
* Add note to developer guide saying it assumes you have read the user guide
