### PR TITLE
Remove servers section as it is optional

### DIFF
--- a/docs/user/reference/asyncapi.yaml
+++ b/docs/user/reference/asyncapi.yaml
@@ -10,11 +10,6 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
-servers:  # TODO: Reference from internal System definition
-  development:
-    url: p45
-    description: Development Test Beamline
-    protocol: STOMP
 defaultContentType: application/json
 channels:
   public.worker.event:


### PR DESCRIPTION
As discussed, remove the server section as it is not appropriate for BlueAPI which only has internal interfaces.