### PR TITLE
Stop models converting to camelCase

### DIFF
--- a/docs/developer/explanations/decisions/0003-api-case.rst
+++ b/docs/developer/explanations/decisions/0003-api-case.rst
@@ -1,0 +1,26 @@
+2. API Model Case
+=================
+
+Date: 2023-05-23
+
+Status
+------
+
+Accepted
+
+Context
+-------
+
+Considering whether keys in JSON blobs from the API should be in snake_case or camelCase.
+This includes plan parameters which may be user-defined.
+
+Decision
+--------
+
+The priority is not to confuse users, so we will not alias any field names defined in Python.
+
+Consequences
+------------
+
+Most code will be written with pep8 enforcers which means most field names will be snake_case.
+Some user defined ones may differ.

--- a/src/blueapi/utils/base_model.py
+++ b/src/blueapi/utils/base_model.py
@@ -17,7 +17,7 @@ class BlueapiModelConfig(BaseConfig):
     allow_population_by_field_name = True
 
 
-class BlueapiPlanModelConfig(BlueapiModelConfig):
+class BlueapiPlanModelConfig(BaseConfig):
     """
     Pydantic config for plan parameters.
     Includes arbitrary type config so that devices
@@ -27,6 +27,7 @@ class BlueapiPlanModelConfig(BlueapiModelConfig):
     from the context.
     """
 
+    extra = Extra.forbid
     arbitrary_types_allowed = True
     validate_all = True
 

--- a/src/blueapi/utils/base_model.py
+++ b/src/blueapi/utils/base_model.py
@@ -1,18 +1,12 @@
 from pydantic import BaseConfig, BaseModel, Extra
 
 
-def _to_camel(string: str) -> str:
-    words = string.split("_")
-    return words[0] + "".join(word.capitalize() for word in words[1:])
-
-
 class BlueapiModelConfig(BaseConfig):
     """
     Pydantic config for blueapi API models with
     common config.
     """
 
-    alias_generator = _to_camel
     extra = Extra.forbid
     allow_population_by_field_name = True
 

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -329,3 +329,14 @@ def test_nested_str_default(
     assert parse_obj_as(model, {}).m == [sim_motor]  # type: ignore
     empty_context.device(alt_motor)
     assert parse_obj_as(model, {"m": [ALT_MOTOR_NAME]}).m == [alt_motor]  # type: ignore
+
+
+def test_plan_models_not_auto_camelcased(empty_context: BlueskyContext) -> None:
+    def a_plan(foo_bar: int, baz: str) -> MsgGenerator:
+        ...
+
+    empty_context.plan(a_plan)
+    assert list(empty_context.plans[a_plan.__name__].model.__fields__.keys()) == [
+        "foo_bar",
+        "baz",
+    ]

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -5,7 +5,7 @@ from typing import Dict, List, Type, Union
 import pytest
 from bluesky.protocols import Descriptor, Movable, Readable, Reading, SyncOrAsync
 from ophyd.sim import SynAxis, SynGauss
-from pydantic import parse_obj_as
+from pydantic import ValidationError, parse_obj_as
 
 from blueapi.config import EnvironmentConfig, Source, SourceKind
 from blueapi.core import (
@@ -337,7 +337,5 @@ def test_plan_models_not_auto_camelcased(empty_context: BlueskyContext) -> None:
             yield
 
     empty_context.plan(a_plan)
-    assert list(empty_context.plans[a_plan.__name__].model.__fields__.keys()) == [
-        "foo_bar",
-        "baz",
-    ]
+    with pytest.raises(ValidationError):
+        empty_context.plans[a_plan.__name__].model(fooBar=1, baz="test")

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -333,7 +333,8 @@ def test_nested_str_default(
 
 def test_plan_models_not_auto_camelcased(empty_context: BlueskyContext) -> None:
     def a_plan(foo_bar: int, baz: str) -> MsgGenerator:
-        ...
+        if False:
+            yield
 
     empty_context.plan(a_plan)
     assert list(empty_context.plans[a_plan.__name__].model.__fields__.keys()) == [

--- a/tests/service/test_rest_api.py
+++ b/tests/service/test_rest_api.py
@@ -78,7 +78,7 @@ def test_get_device_by_name(handler: Handler, client: TestClient) -> None:
 
 def test_create_task(handler: Handler, client: TestClient) -> None:
     response = client.post("/tasks", json=_TASK.dict())
-    task_id = response.json()["taskId"]
+    task_id = response.json()["task_id"]
 
     pending = handler.worker.get_pending_task(task_id)
     assert pending is not None
@@ -87,7 +87,7 @@ def test_create_task(handler: Handler, client: TestClient) -> None:
 
 def test_put_plan_begins_task(handler: Handler, client: TestClient) -> None:
     response = client.post("/tasks", json=_TASK.dict())
-    task_id = response.json()["taskId"]
+    task_id = response.json()["task_id"]
 
     task_json = {"task_id": task_id}
     client.put("/worker/task", json=task_json)

--- a/tests/utils/test_base_model.py
+++ b/tests/utils/test_base_model.py
@@ -11,15 +11,3 @@ def test_snake_case_constructor() -> None:
         hello="hello",
         hello_world="hello world",
     )
-
-
-def test_camel_case_parsing() -> None:
-    assert FooBar.parse_obj(
-        {
-            "hello": "hello",
-            "helloWorld": "hello world",
-        }
-    ) == FooBar(
-        hello="hello",
-        hello_world="hello world",
-    )


### PR DESCRIPTION
Previously with #132, all config, API parameter and plan model parameter names were converted to camelCase when loaded externally (e.g. from JSON). So 

```python
class TaskResponse(BlueapiBaseModel):
    """
    Acknowledgement that a task has started, includes its ID
    """

    task_name: str = Field(description="Unique identifier for the task")
```
Would accept the following via the API:
```json
{"taskName": "my task"}
```

and a plan like

```python
def my_plan(foo_bar: str) -> MsgGenerator:
    ...
```
Would accept:
```json
{"name": "my_plan", "params": {"fooBar": "qwerty"}}
```

This PR removes all aliasing and we accept that there are snake_case models