### PR TITLE
Remove public fields of BlueskyContext and replace with methods

### DIFF
--- a/src/blueapi/core/bluesky_types.py
+++ b/src/blueapi/core/bluesky_types.py
@@ -84,7 +84,7 @@ def is_bluesky_plan_generator(func: PlanGenerator) -> bool:
 
 class Plan(BlueapiBaseModel):
     """
-    A plan that can be run
+    Metadata about a plan that can be run
     """
 
     name: str = Field(description="Referenceable name of the plan")

--- a/src/blueapi/core/context.py
+++ b/src/blueapi/core/context.py
@@ -49,10 +49,7 @@ class BlueskyContext:
     _reference_cache: Dict[Type, Type]
 
     def __init__(self, run_engine: Optional[RunEngine] = None) -> None:
-        if run_engine is None:
-            run_engine = RunEngine(context_managers=[])
-
-        self._run_engine = run_engine
+        self._run_engine = run_engine or RunEngine(context_managers=[])
         self._devices = {}
         self._plans = {}
         self._plan_functions = {}

--- a/src/blueapi/core/context.py
+++ b/src/blueapi/core/context.py
@@ -1,5 +1,4 @@
 import logging
-from dataclasses import field
 from importlib import import_module
 from inspect import Parameter, signature
 from pathlib import Path

--- a/src/blueapi/core/context.py
+++ b/src/blueapi/core/context.py
@@ -62,21 +62,73 @@ class BlueskyContext:
 
     @property
     def run_engine(self) -> RunEngine:
+        """
+        RunEngine capable of running the plans in the context against the devices in the context.
+
+        Returns:
+            RunEngine: A Bluesky RunEngine
+        """
+
         return self._run_engine
 
     def find_plan_function(self, name: str) -> Optional[PlanGenerator]:
+        """
+        Return a plan function matching the given name
+
+        Args:
+            name: The name of the plan
+
+        Returns:
+            Optional[PlanGenerator]: The plan function, None if there is
+                no plan matching the name in the context.
+        """
         return self._plan_functions.get(name)
 
     def find_plan_metadata(self, name: str) -> Optional[Plan]:
+        """
+        Return a metadata object describing a plan in the context
+
+        Args:
+            name: The name of the plan
+
+        Returns:
+            Optional[Plan]: The plan metadata, None if there is
+                no plan matching the name in the context.
+        """
+
         return self._plans.get(name)
 
     def all_devices(self) -> Iterable[Device]:
+        """
+        Return iterable of all devices in the context.
+
+        Returns:
+            Iterable[Device]: Iterable of devices
+        """
+
         return self._devices.values()
 
     def all_plan_metadata(self) -> Iterable[Plan]:
+        """
+        Return iterable of all plan metadata in the context.
+
+        Returns:
+            Iterable[Device]: Iterable of plan metadata
+        """
+
         return self._plans.values()
 
     def has_plan(self, name: str) -> bool:
+        """
+        Check if a plan exists in the context.
+
+        Args:
+            name: The name of the plan
+
+        Returns:
+            bool: True if the plan is accessible from this context
+        """
+
         return name in self._plans
 
     def find_device(self, addr: Union[str, List[str]]) -> Optional[Device]:
@@ -84,11 +136,11 @@ class BlueskyContext:
         Find a device in this context, allows for recursive search.
 
         Args:
-            addr (Union[str, List[str]]): Address of the device, examples:
-                                          "motors", "motors.x"
+            addr: Address of the device, examples: "motors", "motors.x"
 
         Returns:
-            Optional[Device]: _description_
+            Optional[Device]: A Bluesky compatible device, None if no device
+                matching addr exists in the context.
         """
 
         if isinstance(addr, str):
@@ -98,10 +150,27 @@ class BlueskyContext:
             return find_component(self._devices, addr)
 
     def with_startup_script(self, path: Union[Path, str]) -> None:
+        """
+        Register all plans and devices in the Python file at this path.
+
+        Args:
+            path: Path to the Python file. Can be a posix file path
+                or a module path if pointing to a valid Python
+                module in your environment.
+        """
+
         mod = import_module(str(path))
         self.with_module(mod)
 
     def with_module(self, module: ModuleType) -> None:
+        """
+        Register all plans and devices in this module
+
+        Args:
+            module: A module, usually retrieved from an
+                import statement
+        """
+
         self.with_plan_module(module)
         self.with_device_module(module)
 
@@ -122,7 +191,7 @@ class BlueskyContext:
         __all__ = ["plan_1", "plan_2"]
 
         Args:
-            module (ModuleType): Module to pass in
+            module: Module to check for plans
         """
 
         for obj in load_module_all(module):
@@ -130,6 +199,13 @@ class BlueskyContext:
                 self.plan(obj)
 
     def with_device_module(self, module: ModuleType) -> None:
+        """
+        Register all devices in the module supplied
+
+        Args:
+            module: Module to check for devices
+        """
+
         for obj in load_module_all(module):
             if is_bluesky_compatible_device(obj):
                 self.device(obj)
@@ -164,7 +240,7 @@ class BlueskyContext:
         """
         Register an device in the context. The device needs to be registered with a
         name. If the device is Readable, Movable or Flyable it has a `name`
-        attribbute which can be used. The attribute can be overrideen with the
+        attribute which can be used. The attribute can be overridden with the
         `name` parameter here. If the device conforms to a different protocol then
         the parameter must be used to name it.
 

--- a/src/blueapi/core/context.py
+++ b/src/blueapi/core/context.py
@@ -1,5 +1,5 @@
 import logging
-from dataclasses import dataclass, field
+from dataclasses import field
 from importlib import import_module
 from inspect import Parameter, signature
 from pathlib import Path
@@ -47,8 +47,7 @@ class BlueskyContext:
     _plans: Dict[str, Plan]
     _devices: Dict[str, Device]
     _plan_functions: Dict[str, PlanGenerator]
-
-    _reference_cache: Dict[Type, Type] = field(default_factory=dict)
+    _reference_cache: Dict[Type, Type]
 
     def __init__(self, run_engine: Optional[RunEngine] = None) -> None:
         if run_engine is None:
@@ -63,7 +62,8 @@ class BlueskyContext:
     @property
     def run_engine(self) -> RunEngine:
         """
-        RunEngine capable of running the plans in the context against the devices in the context.
+        RunEngine capable of running the plans in the context against the devices
+        in the context.
 
         Returns:
             RunEngine: A Bluesky RunEngine

--- a/src/blueapi/core/context.py
+++ b/src/blueapi/core/context.py
@@ -76,6 +76,9 @@ class BlueskyContext:
     def all_plan_metadata(self) -> Iterable[Plan]:
         return self._plans.values()
 
+    def has_plan(self, name: str) -> bool:
+        return name in self._plans
+
     def find_device(self, addr: Union[str, List[str]]) -> Optional[Device]:
         """
         Find a device in this context, allows for recursive search.

--- a/src/blueapi/service/app.py
+++ b/src/blueapi/service/app.py
@@ -81,7 +81,7 @@ class Service:
             self._template.send(reply_queue, response)
 
     def _get_plans(self, message_context: MessageContext, message: PlanRequest) -> None:
-        plans = list(map(PlanModel.from_plan, self._ctx.plans.values()))
+        plans = list(map(PlanModel.from_plan, self._ctx.all_plan_metadata()))
         response = PlanResponse(plans=plans)
 
         assert message_context.reply_destination is not None
@@ -90,7 +90,7 @@ class Service:
     def _get_devices(
         self, message_context: MessageContext, message: DeviceRequest
     ) -> None:
-        devices = list(map(DeviceModel.from_device, self._ctx.devices.values()))
+        devices = list(map(DeviceModel.from_device, self._ctx.all_devices()))
         response = DeviceResponse(devices=devices)
 
         assert message_context.reply_destination is not None

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -98,7 +98,7 @@ def some_configurable() -> SomeConfigurable:
 @pytest.mark.parametrize("plan", [has_no_params, has_one_param, has_some_params])
 def test_add_plan(empty_context: BlueskyContext, plan: PlanGenerator) -> None:
     empty_context.plan(plan)
-    assert plan.__name__ in empty_context.plans
+    assert empty_context.has_plan(plan.__name__)
 
 
 @pytest.mark.parametrize(
@@ -111,14 +111,14 @@ def test_add_invalid_plan(empty_context: BlueskyContext, plan: PlanGenerator) ->
 
 def test_add_named_device(empty_context: BlueskyContext, sim_motor: SynAxis) -> None:
     empty_context.device(sim_motor)
-    assert empty_context.devices[SIM_MOTOR_NAME] is sim_motor
+    assert empty_context.find_device(SIM_MOTOR_NAME) is sim_motor
 
 
 def test_add_nameless_device(
     empty_context: BlueskyContext, some_configurable: SomeConfigurable
 ) -> None:
     empty_context.device(some_configurable, "conf")
-    assert empty_context.devices["conf"] is some_configurable
+    assert empty_context.find_device("conf") is some_configurable
 
 
 def test_add_nameless_device_without_override(
@@ -133,7 +133,7 @@ def test_override_device_name(
     empty_context: BlueskyContext, sim_motor: SynAxis
 ) -> None:
     empty_context.device(sim_motor, "foo")
-    assert empty_context.devices["foo"] is sim_motor
+    assert empty_context.find_device("foo") is sim_motor
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
It seems more sustainable to use private fields and access them via methods. The device and plan dictionaries and run engine are now hidden behind methods.