### PR TITLE
Fix handling of default parameters in plans

### DIFF
--- a/src/blueapi/core/context.py
+++ b/src/blueapi/core/context.py
@@ -8,10 +8,12 @@ from typing import (
     Any,
     Callable,
     Dict,
+    Generic,
     List,
     Optional,
     Tuple,
     Type,
+    TypeVar,
     Union,
     get_args,
     get_origin,
@@ -219,7 +221,7 @@ class BlueskyContext:
                 )
 
             no_default = para.default is Parameter.empty
-            factory = None if no_default else lambda d=para.default: d
+            factory = None if no_default else DefaultFactory(para.default)
             new_args[name] = (
                 self._convert_type(arg_type),
                 FieldInfo(default_factory=factory),
@@ -252,3 +254,19 @@ class BlueskyContext:
             root = get_origin(typ)
             return root[new_types] if root else typ
         return typ
+
+
+D = TypeVar("D")
+
+
+class DefaultFactory(Generic[D]):
+    _value: D
+
+    def __init__(self, value: D):
+        self._value = value
+
+    def __call__(self) -> D:
+        return self._value
+
+    def __eq__(self, other) -> bool:
+        return other.__class__ == self.__class__ and self._value == other._value

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -12,6 +12,7 @@ from blueapi.core import (
     PlanGenerator,
     is_bluesky_compatible_device,
 )
+from blueapi.core.context import DefaultFactory
 
 #
 # Dummy plans
@@ -171,7 +172,10 @@ def test_add_non_device(empty_context: BlueskyContext) -> None:
 
 def test_function_spec(empty_context: BlueskyContext) -> None:
     spec = empty_context._type_spec_for_function(has_some_params)
-    assert spec == {"foo": (int, 42), "bar": (str, "bar")}
+    assert spec["foo"][0] == int
+    assert spec["foo"][1].default_factory == DefaultFactory(42)
+    assert spec["bar"][0] == str
+    assert spec["bar"][1].default_factory == DefaultFactory("bar")
 
 
 def test_basic_type_conversion(empty_context: BlueskyContext) -> None:
@@ -213,4 +217,5 @@ def test_concrete_method_annotation(empty_context: BlueskyContext) -> None:
         ...
 
     spec = empty_context._type_spec_for_function(demo)
-    assert spec == {"named": (hasname_ref, None)}
+    assert spec["named"][0] is hasname_ref
+    assert spec["named"][1].default_factory is None

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -197,6 +197,16 @@ def test_reference_type_conversion(empty_context: BlueskyContext) -> None:
     )
 
 
+def test_default_device_reference(empty_context: BlueskyContext) -> None:
+    def default_movable(mov: Movable = "demo") -> MsgGenerator:  # type: ignore
+        ...
+
+    spec = empty_context._type_spec_for_function(default_movable)
+    movable_ref = empty_context._reference(Movable)
+    assert spec["mov"][0] == movable_ref
+    assert spec["mov"][1].default_factory == DefaultFactory("demo")
+
+
 class Named:
     """Concrete implementation of a Bluesky protocol (HasName)"""
 


### PR DESCRIPTION
Passing `None` as the default for a field sets the default to None and
is different to there being no default.

If a default value is given, it is now returned via a default_factory.
This is required to prevent pydantic errors when the default is an ophyd
device.
