### PR TITLE
Make more dependencies optional

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,13 +18,9 @@ dependencies = [
     "nslsii",
     "pyepics",
     "pydantic",
-    "stomp.py",
     "scanspec",
     "PyYAML",
     "click",
-    "fastapi[all]",
-    "uvicorn",
-    "requests",
 ]
 dynamic = ["version"]
 license.file = "LICENSE"
@@ -32,6 +28,9 @@ readme = "README.rst"
 requires-python = ">=3.9"
 
 [project.optional-dependencies]
+rest = ["fastapi[all]", "uvicorn"]
+stomp = ["stomp.py"]
+client = ["requests"]
 dev = [
     "black",
     "mypy",


### PR DESCRIPTION
Some use cases involve using blueapi as a library. In these cases, users may not want to depend on I/O libraries such as fastapi and stomp.
This change separates those into optional dependencies so that the full suite of functionality can only be achieved via a pip install blueapi[all].