### PR TITLE
Made tests work with server running

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,9 @@ addopts = """
 filterwarnings = ["error", "ignore::DeprecationWarning"]
 # Doctest python code in docs, python code in src docstrings, test functions in tests
 testpaths = "docs src tests"
+markers = [
+    "handler: marks tests that interact with the global handler object in handler.py",
+]
 
 [tool.coverage.run]
 data_file = "/tmp/blueapi.coverage"

--- a/tests/service/test_handler.py
+++ b/tests/service/test_handler.py
@@ -10,7 +10,7 @@ from blueapi.service.handler import (
 
 
 @patch("blueapi.service.handler.Handler")
-def test_get_handler_raises_before_setup_hadler_called(
+def test_get_handler_raises_before_setup_handler_called(
     mock_handler: Mock, handler: Handler
 ):
     mock_handler.side_effect = Mock(return_value=handler)
@@ -23,3 +23,7 @@ def test_get_handler_raises_before_setup_hadler_called(
     assert handler
 
     teardown_handler()
+
+
+def test_teardown_handler_does_nothing_if_setup_handler_not_called():
+    assert teardown_handler() is None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -48,7 +48,7 @@ def test_main_with_nonexistent_config_file():
 
 
 @patch("requests.get")
-def test_controller_plans(mock_requests: Mock):
+def test_connection_error_caught_by_wrapper_func(mock_requests: Mock):
     mock_requests.side_effect = ConnectionError()
     runner = CliRunner()
     result = runner.invoke(main, ["controller", "plans"])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,6 +5,7 @@ from click.testing import CliRunner
 from fastapi.testclient import TestClient
 from mock import Mock, patch
 from pydantic import BaseModel
+from requests.exceptions import ConnectionError
 
 from blueapi import __version__
 from blueapi.cli.cli import main
@@ -39,7 +40,9 @@ def test_main_with_nonexistent_config_file():
     type(result.exception) == FileNotFoundError
 
 
-def test_controller_plans():
+@patch("requests.get")
+def test_controller_plans(mock_requests: Mock):
+    mock_requests.side_effect = ConnectionError()
     runner = CliRunner()
     result = runner.invoke(main, ["controller", "plans"])
 


### PR DESCRIPTION
This was a simple bug; one of the tests in test_cli.py assumed the server isn't running, which means if it is, it fails.

I've mocked out the api call this makes now. So now the tests work with the server running.