### PR TITLE
Fix exception logging in stomptemplate

### DIFF
--- a/src/blueapi/messaging/stomptemplate.py
+++ b/src/blueapi/messaging/stomptemplate.py
@@ -192,8 +192,8 @@ class StompMessagingTemplate(MessagingTemplate):
         while not self._conn.is_connected():
             try:
                 self.connect()
-            except ConnectFailedException as ex:
-                LOGGER.error("Reconnect failed", ex)
+            except ConnectFailedException:
+                LOGGER.exception("Reconnect failed")
             time.sleep(self._reconnect_policy.attempt_period)
 
     @handle_all_exceptions


### PR DESCRIPTION
Previously logging failed due to supply of parameter without a formatting placeholder in the message.