### PR TITLE
Correlation id

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
             "request": "launch",
             "module": "uvicorn",
             "args": [
-                "src.blueapi.rest.main:app",
+                "src.blueapi.service.main:app",
                 "--reload"
             ],
             "jinja": true,

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -4,4 +4,4 @@ stomp:
   host: localhost
   port: 61613
 logging:
-  level: "INFO"
+  level: "DEBUG"

--- a/src/blueapi/cli/amq.py
+++ b/src/blueapi/cli/amq.py
@@ -30,10 +30,6 @@ class AmqClient:
         """Run callbacks on events/progress events with a given correlation id."""
 
         def on_event_wrapper(ctx: MessageContext, event: WorkerEvent) -> None:
-            print(
-                f"correlation_id: {ctx.correlation_id}, corr_id: {corr_id}, "
-                + f"event.is_complete: {event.is_complete()}"
-            )
             if (on_event is not None) and (ctx.correlation_id == corr_id):
                 on_event(event)
 

--- a/src/blueapi/cli/cli.py
+++ b/src/blueapi/cli/cli.py
@@ -118,7 +118,7 @@ def run_plan(obj: dict, name: str, parameters: str, id: Optional[str] = None) ->
         request_str + f"?correlation_id={corr_id}",
         json=json.loads(parameters),
     )
-    # client.wait_for_complete()
+    client.wait_for_complete()
 
     # resp should contain the task_id.
     # setup listener to activemq for a topic with this task_id...

--- a/src/blueapi/messaging/context.py
+++ b/src/blueapi/messaging/context.py
@@ -10,4 +10,4 @@ class MessageContext:
 
     destination: str
     reply_destination: Optional[str]
-    correlation_id: Optional[str]
+    correlation_id: str

--- a/src/blueapi/service/handler.py
+++ b/src/blueapi/service/handler.py
@@ -1,5 +1,6 @@
 import logging
 from typing import Mapping, Optional
+from blueapi.cli.amq import AmqClient
 
 from blueapi.config import ApplicationConfig
 from blueapi.core import BlueskyContext
@@ -15,6 +16,7 @@ class Handler:
     worker: Worker
     config: ApplicationConfig
     message_bus: MessagingTemplate
+    amq_client: AmqClient
 
     def __init__(self, config: Optional[ApplicationConfig] = None) -> None:
         self.context = BlueskyContext()
@@ -26,6 +28,7 @@ class Handler:
 
         self.worker = RunEngineWorker(self.context)
         self.message_bus = StompMessagingTemplate.autoconfigured(self.config.stomp)
+        self.amq_client = AmqClient(self.message_bus)
 
     def start(self) -> None:
         self.worker.start()

--- a/src/blueapi/service/handler.py
+++ b/src/blueapi/service/handler.py
@@ -1,8 +1,9 @@
 import logging
-from typing import Optional
+from typing import Mapping, Optional
 
 from blueapi.config import ApplicationConfig
 from blueapi.core import BlueskyContext
+from blueapi.core.event import EventStream
 from blueapi.messaging import StompMessagingTemplate
 from blueapi.messaging.base import MessagingTemplate
 from blueapi.worker.reworker import RunEngineWorker
@@ -29,23 +30,34 @@ class Handler:
     def start(self) -> None:
         self.worker.start()
 
-        self.worker.data_events.subscribe(
-            lambda event, corr_id: self.message_bus.send(
-                "public.worker.event.data", event, None, corr_id
-            )
-        )
-        self.worker.progress_events.subscribe(
-            lambda event, corr_id: self.message_bus.send(
-                "public.worker.event.progress", event, None, corr_id
-            )
-        )
-        self.worker.worker_events.subscribe(
-            lambda event, corr_id: self.message_bus.send(
-                "public.worker.event", event, None, corr_id
-            )
+        self._publish_event_streams(
+            {
+                self.worker.worker_events: self.message_bus.destinations.topic(
+                    "public.worker.event"
+                ),
+                self.worker.progress_events: self.message_bus.destinations.topic(
+                    "public.worker.event.progress"
+                ),
+                self.worker.data_events: self.message_bus.destinations.topic(
+                    "public.worker.event.data"
+                ),
+            }
         )
 
         self.message_bus.connect()
+
+    def _publish_event_streams(
+        self, streams_to_destinations: Mapping[EventStream, str]
+    ) -> None:
+        for stream, destination in streams_to_destinations.items():
+            self._publish_event_stream(stream, destination)
+
+    def _publish_event_stream(self, stream: EventStream, destination: str) -> None:
+        stream.subscribe(
+            lambda event, correlation_id: self.message_bus.send(
+                destination, event, None, correlation_id
+            )
+        )
 
     def stop(self) -> None:
         self.worker.stop()

--- a/src/blueapi/service/handler.py
+++ b/src/blueapi/service/handler.py
@@ -39,6 +39,11 @@ class Handler:
                 "public.worker.event.progress", event, None, corr_id
             )
         )
+        self.worker.worker_events.subscribe(
+            lambda event, corr_id: self.message_bus.send(
+                "public.worker.event", event, None, corr_id
+            )
+        )
 
         self.message_bus.connect()
 

--- a/src/blueapi/service/main.py
+++ b/src/blueapi/service/main.py
@@ -1,6 +1,6 @@
-from typing import Any, Mapping
+from typing import Any, Mapping, Optional
 
-from fastapi import Body, Depends, FastAPI, HTTPException
+from fastapi import Body, Depends, FastAPI, HTTPException, Query
 
 from blueapi.config import ApplicationConfig
 from blueapi.worker import RunPlan
@@ -52,11 +52,12 @@ async def get_device_by_name(name: str, handler: Handler = Depends(get_handler))
 async def submit_task(
     name: str,
     task: Mapping[str, Any] = Body(..., example={"detectors": ["x"]}),
+    correlation_id: str = Query(...),
     handler: Handler = Depends(get_handler),
 ):
     """Submit a task onto the worker queue."""
-    handler.worker.submit_task(name, RunPlan(name=name, params=task))
-    return TaskResponse(task_name=name)
+    handler.worker.submit_task(name, RunPlan(name=name, params=task), correlation_id)
+    return TaskResponse(task_id=correlation_id)
 
 
 def start(config: ApplicationConfig):

--- a/src/blueapi/service/model.py
+++ b/src/blueapi/service/model.py
@@ -80,4 +80,4 @@ class TaskResponse(BlueapiBaseModel):
     Acknowledgement that a task has started, includes its ID
     """
 
-    task_name: str = Field(description="Unique identifier for the task")
+    task_id: str = Field(description="Unique identifier for the task")

--- a/src/blueapi/worker/reworker.py
+++ b/src/blueapi/worker/reworker.py
@@ -102,7 +102,7 @@ class RunEngineWorker(Worker[Task]):
             if self._pending_transaction is None:
                 raise Exception("No transaction to clear")
 
-            task_id = self._pending_transaction.name
+            task_id = self._pending_transaction.task_id
             self._pending_transaction = None
             return task_id
 
@@ -111,7 +111,7 @@ class RunEngineWorker(Worker[Task]):
             if self._pending_transaction is None:
                 raise Exception("No transaction to commit")
 
-            pending_id = self._pending_transaction.name
+            pending_id = self._pending_transaction.task_id
             if pending_id == task_id:
                 self._submit_active_task(self._pending_transaction)
             else:
@@ -240,11 +240,11 @@ class RunEngineWorker(Worker[Task]):
         warnings = self._warnings
         if self._current is not None:
             task_status = TaskStatus(
-                task_name=self._current.name,
+                task_name=self._current.task_id,
                 task_complete=self._current.is_complete,
                 task_failed=self._current.is_error or bool(errors),
             )
-            correlation_id = self._current.correlation_id
+            correlation_id = self._current.task_id
         else:
             task_status = None
             correlation_id = None
@@ -259,7 +259,7 @@ class RunEngineWorker(Worker[Task]):
 
     def _on_document(self, name: str, document: Mapping[str, Any]) -> None:
         if self._current is not None:
-            correlation_id = self._current.correlation_id
+            correlation_id = self._current.task_id
             self._data_events.publish(
                 DataEvent(name=name, doc=document), correlation_id
             )
@@ -330,10 +330,10 @@ class RunEngineWorker(Worker[Task]):
         else:
             self._progress_events.publish(
                 ProgressEvent(
-                    task_name=self._current.name,
+                    task_name=self._current.task_id,
                     statuses=self._status_snapshot,
                 ),
-                self._current.correlation_id,
+                self._current.task_id,
             )
 
 

--- a/src/blueapi/worker/task.py
+++ b/src/blueapi/worker/task.py
@@ -69,6 +69,7 @@ def _lookup_params(
 
 @dataclass
 class ActiveTask:
+    correlation_id: str
     name: str
     task: Task
     is_complete: bool = False

--- a/src/blueapi/worker/task.py
+++ b/src/blueapi/worker/task.py
@@ -69,7 +69,6 @@ def _lookup_params(
 
 @dataclass
 class ActiveTask:
-    correlation_id: str
     name: str
     task: Task
     is_complete: bool = False

--- a/src/blueapi/worker/task.py
+++ b/src/blueapi/worker/task.py
@@ -69,7 +69,7 @@ def _lookup_params(
 
 @dataclass
 class ActiveTask:
-    name: str
+    task_id: str
     task: Task
     is_complete: bool = False
     is_error: bool = False

--- a/src/blueapi/worker/worker.py
+++ b/src/blueapi/worker/worker.py
@@ -26,11 +26,11 @@ class Worker(ABC, Generic[T]):
         """
 
     @abstractmethod
-    def clear_transaction(self) -> None:
+    def clear_transaction(self) -> str:
         """_summary_"""
 
     @abstractmethod
-    def commit_transaction(self) -> None:
+    def commit_transaction(self, __task_id: str) -> None:
         """_summary_"""
 
     @abstractmethod

--- a/src/blueapi/worker/worker.py
+++ b/src/blueapi/worker/worker.py
@@ -15,7 +15,34 @@ class Worker(ABC, Generic[T]):
     """
 
     @abstractmethod
-    def submit_task(self, __name: str, __task: T, __correlation_id: str) -> None:
+    def begin_transaction(self, __task: T) -> str:
+        """_summary_
+
+        Args:
+            __task (Task): _description_
+
+        Returns:
+            str: _description_
+        """
+
+    @abstractmethod
+    def clear_transaction(self) -> None:
+        """_summary_"""
+
+    @abstractmethod
+    def commit_transaction(self) -> None:
+        """_summary_"""
+
+    @abstractmethod
+    def get_pending(self) -> Optional[T]:
+        """_summary_
+
+        Returns:
+            Optional[Task]: _description_
+        """
+
+    @abstractmethod
+    def submit_task(self, __task_id: str, __task: T) -> None:
         """
         Submit a task to be run
 

--- a/src/blueapi/worker/worker.py
+++ b/src/blueapi/worker/worker.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Generic, TypeVar
+from typing import Generic, Optional, TypeVar
 
 from blueapi.core import DataEvent, EventStream
 
@@ -15,13 +15,14 @@ class Worker(ABC, Generic[T]):
     """
 
     @abstractmethod
-    def submit_task(self, __name: str, __task: T) -> None:
+    def submit_task(self, __name: str, __task: T, __correlation_id: str) -> None:
         """
         Submit a task to be run
 
         Args:
-            __name (str): A unique name to identify this task
+            __name (str): name of the plan to be run
             __task (T): The task to run
+            __correlation_id (str): unique identifier of the task
         """
 
     @abstractmethod


### PR DESCRIPTION
Attempts to deal with correlation id via CLI and rest api.

The concept is, whatever is calling the rest API will already have some correlation id for the plan to be run. 
This PR should allow the client to call the server via the CLI to:
1. put a plan onto the queue (with some correlation id). This will return immediately.
2. Check for the status of a plan with some correlation id.

I'm not yet sure the best way of restfully accomplishing these tasks. So far, I've just done everything through the CLI run_plan function, but this handles the active mq subscriptions directly which doesn't seem smart. It seems better to have some sort of 'cache' of bluesky events that can be accessed by the rest API to get the latest status.