### PR TITLE
Add transaction mode to worker

### DIFF
--- a/docs/developer/explanations/decisions/0002-no-queues.rst
+++ b/docs/developer/explanations/decisions/0002-no-queues.rst
@@ -1,0 +1,27 @@
+2. No Queues
+============
+
+Date: 2023-05-22
+
+Status
+------
+
+Accepted
+
+Context
+-------
+
+In asking whether this service should hold and execute a queue of tasks.
+
+Decision
+--------
+
+We will not hold any queues. The worker can execute one task at a time and will return
+an error if asked to execute one task while another is running. Queueing should be the
+responsibility of a different service.
+
+Consequences
+------------
+
+The API must be kept queue-free, although transactions are permitted where the server
+caches requests.

--- a/src/blueapi/cli/amq.py
+++ b/src/blueapi/cli/amq.py
@@ -61,7 +61,7 @@ class AmqClient:
         task_response = self.app.send_and_receive(
             "worker.run", {"name": name, "params": params}, reply_type=TaskResponse
         ).result(5.0)
-        task_id = task_response.task_name
+        task_id = task_response.task_id
 
         if timeout is not None:
             complete.wait(timeout)

--- a/src/blueapi/cli/updates.py
+++ b/src/blueapi/cli/updates.py
@@ -43,15 +43,15 @@ class ProgressBarRenderer:
 
 
 class CliEventRenderer:
-    _task_name: Optional[str]
+    _task_id: Optional[str]
     _pbar_renderer: ProgressBarRenderer
 
     def __init__(
         self,
-        task_name: Optional[str] = None,
+        task_id: Optional[str] = None,
         pbar_renderer: Optional[ProgressBarRenderer] = None,
     ) -> None:
-        self._task_name = task_name
+        self._task_id = task_id
         if pbar_renderer is None:
             pbar_renderer = ProgressBarRenderer()
         self._pbar_renderer = pbar_renderer
@@ -65,14 +65,14 @@ class CliEventRenderer:
             print(str(event.state))
 
     def _relates_to_task(self, event: Union[WorkerEvent, ProgressEvent]) -> bool:
-        if self._task_name is None:
+        if self._task_id is None:
             return True
         elif isinstance(event, WorkerEvent):
             return (
                 event.task_status is not None
-                and event.task_status.task_name == self._task_name
+                and event.task_status.task_id == self._task_id
             )
         elif isinstance(event, ProgressEvent):
-            return event.task_name == self._task_name
+            return event.task_id == self._task_id
         else:
             return False

--- a/src/blueapi/core/event.py
+++ b/src/blueapi/core/event.py
@@ -1,6 +1,5 @@
 import itertools
 from abc import ABC, abstractmethod
-from copy import copy
 from typing import Callable, Dict, Generic, Optional, TypeVar
 
 #: Event type

--- a/src/blueapi/core/event.py
+++ b/src/blueapi/core/event.py
@@ -1,5 +1,6 @@
 import itertools
 from abc import ABC, abstractmethod
+from copy import copy
 from typing import Callable, Dict, Generic, Optional, TypeVar
 
 #: Event type

--- a/src/blueapi/service/main.py
+++ b/src/blueapi/service/main.py
@@ -72,7 +72,7 @@ def submit_task(
     """Submit a task onto the worker queue."""
     task_id = handler.worker.submit_task(RunPlan(name=name, params=task))
     handler.worker.begin_task(task_id)
-    return TaskResponse(task_name=task_id)
+    return TaskResponse(task_id=task_id)
 
 
 @app.get("/worker/state")

--- a/src/blueapi/service/main.py
+++ b/src/blueapi/service/main.py
@@ -70,8 +70,9 @@ def submit_task(
     handler: Handler = Depends(get_handler),
 ):
     """Submit a task onto the worker queue."""
-    handler.worker.submit_task(name, RunPlan(name=name, params=task))
-    return TaskResponse(task_name=name)
+    task_id = handler.worker.submit_task(RunPlan(name=name, params=task))
+    handler.worker.begin_task(task_id)
+    return TaskResponse(task_name=task_id)
 
 
 @app.get("/worker/state")

--- a/src/blueapi/service/model.py
+++ b/src/blueapi/service/model.py
@@ -80,4 +80,4 @@ class TaskResponse(BlueapiBaseModel):
     Acknowledgement that a task has started, includes its ID
     """
 
-    task_name: str = Field(description="Unique identifier for the task")
+    task_id: str = Field(description="Unique identifier for the task")

--- a/src/blueapi/worker/__init__.py
+++ b/src/blueapi/worker/__init__.py
@@ -2,7 +2,8 @@ from .event import ProgressEvent, StatusView, TaskStatus, WorkerEvent, WorkerSta
 from .multithread import run_worker_in_own_thread
 from .reworker import RunEngineWorker
 from .task import RunPlan, Task
-from .worker import Worker
+from .worker import TrackableTask, Worker
+from .worker_busy_error import WorkerBusyError
 
 __all__ = [
     "run_worker_in_own_thread",
@@ -15,4 +16,6 @@ __all__ = [
     "StatusView",
     "ProgressEvent",
     "TaskStatus",
+    "TrackableTask",
+    "WorkerBusyError",
 ]

--- a/src/blueapi/worker/event.py
+++ b/src/blueapi/worker/event.py
@@ -88,7 +88,7 @@ class ProgressEvent(BlueapiBaseModel):
     such as moving motors and exposing detectors.
     """
 
-    task_name: str
+    task_id: str
     statuses: Mapping[str, StatusView] = Field(default_factory=dict)
 
 
@@ -97,7 +97,7 @@ class TaskStatus(BlueapiBaseModel):
     Status of a task the worker is running.
     """
 
-    task_name: str
+    task_id: str
     task_complete: bool
     task_failed: bool
 

--- a/src/blueapi/worker/reworker.py
+++ b/src/blueapi/worker/reworker.py
@@ -25,8 +25,8 @@ from .event import (
     WorkerState,
 )
 from .multithread import run_worker_in_own_thread
-from .task import Task, TrackableTask
-from .worker import Worker
+from .task import Task
+from .worker import TrackableTask, Worker
 from .worker_busy_error import WorkerBusyError
 
 LOGGER = logging.getLogger(__name__)
@@ -96,8 +96,8 @@ class RunEngineWorker(Worker[Task]):
         else:
             return False
 
-    def get_pending_tasks(self) -> List[Task]:
-        return [trackable_task.task for trackable_task in self._pending_tasks.values()]
+    def get_pending_tasks(self) -> List[TrackableTask[Task]]:
+        return list(self._pending_tasks.values())
 
     def begin_task(self, task_id: str) -> None:
         task = self._pending_tasks.get(task_id)
@@ -108,7 +108,7 @@ class RunEngineWorker(Worker[Task]):
 
     def submit_task(self, task: Task) -> str:
         task_id: str = str(uuid.uuid4())
-        trackable_task = TrackableTask(task_id, task)
+        trackable_task = TrackableTask(task_id=task_id, task=task)
         self._pending_tasks[task_id] = trackable_task
         return task_id
 

--- a/src/blueapi/worker/reworker.py
+++ b/src/blueapi/worker/reworker.py
@@ -97,25 +97,25 @@ class RunEngineWorker(Worker[Task]):
             return False
 
     def get_pending_tasks(self) -> List[Task]:
-        return [active_task.task for active_task in self._pending_tasks.values()]
+        return [trackable_task.task for trackable_task in self._pending_tasks.values()]
 
     def begin_task(self, task_id: str) -> None:
         task = self._pending_tasks.get(task_id)
         if task is not None:
-            self._submit_active_task(task)
+            self._submit_trackable_task(task)
         else:
             raise KeyError(f"No pending task with ID {task_id}")
 
     def submit_task(self, task: Task) -> str:
         task_id: str = str(uuid.uuid4())
-        active_task = TrackableTask(task_id, task)
-        self._pending_tasks[task_id] = active_task
+        trackable_task = TrackableTask(task_id, task)
+        self._pending_tasks[task_id] = trackable_task
         return task_id
 
-    def _submit_active_task(self, active_task: TrackableTask) -> None:
-        LOGGER.info(f"Submitting: {active_task}")
+    def _submit_trackable_task(self, trackable_task: TrackableTask) -> None:
+        LOGGER.info(f"Submitting: {trackable_task}")
         try:
-            self._task_queue.put_nowait(active_task)
+            self._task_queue.put_nowait(trackable_task)
         except Full:
             LOGGER.error("Cannot submit task while another is running")
             raise WorkerBusyError("Cannot submit task while another is running")

--- a/src/blueapi/worker/reworker.py
+++ b/src/blueapi/worker/reworker.py
@@ -315,10 +315,10 @@ class RunEngineWorker(Worker[Task]):
         else:
             self._progress_events.publish(
                 ProgressEvent(
-                    task_name=self._current.name,
+                    task_name=self._current.task_id,
                     statuses=self._status_snapshot,
                 ),
-                self._current.name,
+                self._current.task_id,
             )
 
 

--- a/src/blueapi/worker/reworker.py
+++ b/src/blueapi/worker/reworker.py
@@ -102,7 +102,7 @@ class RunEngineWorker(Worker[Task]):
     def clear_transaction(self) -> str:
         with self._transaction_lock:
             if self._pending_transaction is None:
-                raise Exception("No transaction to clear")
+                raise KeyError("No transaction to clear")
 
             task_id = self._pending_transaction.task_id
             self._pending_transaction = None
@@ -111,7 +111,7 @@ class RunEngineWorker(Worker[Task]):
     def commit_transaction(self, task_id: str) -> None:
         with self._transaction_lock:
             if self._pending_transaction is None:
-                raise Exception("No transaction to commit")
+                raise KeyError("No transaction to commit")
 
             pending_id = self._pending_transaction.task_id
             if pending_id == task_id:

--- a/src/blueapi/worker/reworker.py
+++ b/src/blueapi/worker/reworker.py
@@ -226,7 +226,7 @@ class RunEngineWorker(Worker[Task]):
         warnings = self._warnings
         if self._current is not None:
             task_status = TaskStatus(
-                task_name=self._current.task_id,
+                task_id=self._current.task_id,
                 task_complete=self._current.is_complete,
                 task_failed=self._current.is_error or bool(errors),
             )
@@ -319,7 +319,7 @@ class RunEngineWorker(Worker[Task]):
         else:
             self._progress_events.publish(
                 ProgressEvent(
-                    task_name=self._current.task_id,
+                    task_id=self._current.task_id,
                     statuses=self._status_snapshot,
                 ),
                 self._current.task_id,

--- a/src/blueapi/worker/reworker.py
+++ b/src/blueapi/worker/reworker.py
@@ -89,8 +89,12 @@ class RunEngineWorker(Worker[Task]):
         self._stopping = Event()
         self._stopped = Event()
 
-    def clear_task(self, task_id: str) -> None:
-        del self._pending_tasks[task_id]
+    def clear_task(self, task_id: str) -> bool:
+        if task_id in self._pending_tasks:
+            del self._pending_tasks[task_id]
+            return True
+        else:
+            return False
 
     def get_pending_tasks(self) -> List[Task]:
         return [active_task.task for active_task in self._pending_tasks.values()]

--- a/src/blueapi/worker/task.py
+++ b/src/blueapi/worker/task.py
@@ -68,7 +68,12 @@ def _lookup_params(
 
 
 @dataclass
-class ActiveTask:
+class TrackableTask:
+    """
+    An internal representation for use by the worker, holding a
+    task with it's ID and current status
+    """
+
     task_id: str
     task: Task
     is_complete: bool = False

--- a/src/blueapi/worker/task.py
+++ b/src/blueapi/worker/task.py
@@ -1,6 +1,5 @@
 import logging
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
 from typing import Any, Mapping
 
 from pydantic import BaseModel, Field, parse_obj_as

--- a/src/blueapi/worker/task.py
+++ b/src/blueapi/worker/task.py
@@ -69,7 +69,7 @@ def _lookup_params(
 
 @dataclass
 class ActiveTask:
-    name: str
+    task_id: str
     task: Task
     is_complete: bool = False
     is_error: bool = False

--- a/src/blueapi/worker/task.py
+++ b/src/blueapi/worker/task.py
@@ -65,16 +65,3 @@ def _lookup_params(
 
     model = plan.model
     return parse_obj_as(model, params)
-
-
-@dataclass
-class TrackableTask:
-    """
-    An internal representation for use by the worker, holding a
-    task with it's ID and current status
-    """
-
-    task_id: str
-    task: Task
-    is_complete: bool = False
-    is_error: bool = False

--- a/src/blueapi/worker/worker.py
+++ b/src/blueapi/worker/worker.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Generic, List, Optional, TypeVar
+from typing import Generic, List, TypeVar
 
 from blueapi.core import DataEvent, EventStream
 

--- a/src/blueapi/worker/worker.py
+++ b/src/blueapi/worker/worker.py
@@ -16,37 +16,46 @@ class Worker(ABC, Generic[T]):
 
     @abstractmethod
     def get_pending_tasks(self) -> List[T]:
-        """_summary_
+        """
+        Return a list of all tasks pending on the worker,
+        any one of which can be triggered with begin_task.
 
         Returns:
-            List[T]: _description_
+            List[T]: List of task objects
         """
 
     @abstractmethod
     def clear_task(self, task_id: str) -> bool:
-        """_summary_
+        """
+        Remove a pending task from the worker
 
         Args:
-            task_id (str): _description_
+            task_id: The ID of the task to be removed
+        Returns:
+            bool: True if the task existed in the first place
         """
 
     @abstractmethod
     def begin_task(self, task_id: str) -> None:
-        """_summary_
+        """
+        Trigger a pending task. Will fail if the worker is busy.
 
         Args:
-            task_id (str): _description_
+            task_id: The ID of the task to be triggered
+        Throws:
+            WorkerBusyError: If the worker is already running a task.
+            KeyError: If the task ID does not exist
         """
 
     @abstractmethod
     def submit_task(self, task: T) -> str:
         """
-        Submit a task to be run
+        Submit a task to be run on begin_task
 
         Args:
-            __name (str): name of the plan to be run
-            __task (T): The task to run
-            __correlation_id (str): unique identifier of the task
+            task: A description of the task
+        Returns:
+            str: A unique ID to refer to this task
         """
 
     @abstractmethod

--- a/src/blueapi/worker/worker.py
+++ b/src/blueapi/worker/worker.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Generic, Optional, TypeVar
+from typing import Generic, List, Optional, TypeVar
 
 from blueapi.core import DataEvent, EventStream
 
@@ -15,49 +15,31 @@ class Worker(ABC, Generic[T]):
     """
 
     @abstractmethod
-    def begin_transaction(self, __task: T) -> str:
-        """
-        Begin a new transaction, lock the worker with a pending task,
-        do not allow new transactions until this one is run or cleared.
-
-        Args:
-            __task: The task to run if this transaction is committed
-
-        Returns:
-            str: An ID for the task
-        """
-
-    @abstractmethod
-    def clear_transaction(self) -> str:
-        """
-        Clear any existing transaction. Raise an error if
-        unable.
-
-        Returns:
-            str: The ID of the task cleared
-        """
-
-    @abstractmethod
-    def commit_transaction(self, __task_id: str) -> None:
-        """
-        Commit the pending transaction and run the
-        embedded task
-
-        Args:
-            __task_id: The ID of the task to run, must match
-                the pending transaction
-        """
-
-    @abstractmethod
-    def get_pending(self) -> Optional[T]:
+    def get_pending_tasks(self) -> List[T]:
         """_summary_
 
         Returns:
-            Optional[Task]: _description_
+            List[T]: _description_
         """
 
     @abstractmethod
-    def submit_task(self, __task_id: str, __task: T) -> None:
+    def clear_task(self, task_id: str) -> None:
+        """_summary_
+
+        Args:
+            task_id (str): _description_
+        """
+
+    @abstractmethod
+    def begin_task(self, task_id: str) -> None:
+        """_summary_
+
+        Args:
+            task_id (str): _description_
+        """
+
+    @abstractmethod
+    def submit_task(self, task: T) -> str:
         """
         Submit a task to be run
 

--- a/src/blueapi/worker/worker.py
+++ b/src/blueapi/worker/worker.py
@@ -2,10 +2,22 @@ from abc import ABC, abstractmethod
 from typing import Generic, List, TypeVar
 
 from blueapi.core import DataEvent, EventStream
+from blueapi.utils import BlueapiBaseModel
 
 from .event import ProgressEvent, WorkerEvent, WorkerState
 
 T = TypeVar("T")
+
+
+class TrackableTask(BlueapiBaseModel, Generic[T]):
+    """
+    A representation of a task that the worker recognizes
+    """
+
+    task_id: str
+    task: T
+    is_complete: bool = False
+    is_error: bool = False
 
 
 class Worker(ABC, Generic[T]):
@@ -15,13 +27,13 @@ class Worker(ABC, Generic[T]):
     """
 
     @abstractmethod
-    def get_pending_tasks(self) -> List[T]:
+    def get_pending_tasks(self) -> List[TrackableTask[T]]:
         """
         Return a list of all tasks pending on the worker,
         any one of which can be triggered with begin_task.
 
         Returns:
-            List[T]: List of task objects
+            List[TrackableTask[T]]: List of task objects
         """
 
     @abstractmethod

--- a/src/blueapi/worker/worker.py
+++ b/src/blueapi/worker/worker.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Generic, TypeVar
+from typing import Generic, Optional, TypeVar
 
 from blueapi.core import DataEvent, EventStream
 
@@ -15,13 +15,56 @@ class Worker(ABC, Generic[T]):
     """
 
     @abstractmethod
-    def submit_task(self, __name: str, __task: T) -> None:
+    def begin_transaction(self, __task: T) -> str:
+        """
+        Begin a new transaction, lock the worker with a pending task,
+        do not allow new transactions until this one is run or cleared.
+
+        Args:
+            __task: The task to run if this transaction is committed
+
+        Returns:
+            str: An ID for the task
+        """
+
+    @abstractmethod
+    def clear_transaction(self) -> str:
+        """
+        Clear any existing transaction. Raise an error if
+        unable.
+
+        Returns:
+            str: The ID of the task cleared
+        """
+
+    @abstractmethod
+    def commit_transaction(self, __task_id: str) -> None:
+        """
+        Commit the pending transaction and run the
+        embedded task
+
+        Args:
+            __task_id: The ID of the task to run, must match
+                the pending transaction
+        """
+
+    @abstractmethod
+    def get_pending(self) -> Optional[T]:
+        """_summary_
+
+        Returns:
+            Optional[Task]: _description_
+        """
+
+    @abstractmethod
+    def submit_task(self, __task_id: str, __task: T) -> None:
         """
         Submit a task to be run
 
         Args:
-            __name (str): A unique name to identify this task
+            __name (str): name of the plan to be run
             __task (T): The task to run
+            __correlation_id (str): unique identifier of the task
         """
 
     @abstractmethod

--- a/src/blueapi/worker/worker.py
+++ b/src/blueapi/worker/worker.py
@@ -23,7 +23,7 @@ class Worker(ABC, Generic[T]):
         """
 
     @abstractmethod
-    def clear_task(self, task_id: str) -> None:
+    def clear_task(self, task_id: str) -> bool:
         """_summary_
 
         Args:

--- a/tests/service/test_rest_api.py
+++ b/tests/service/test_rest_api.py
@@ -1,3 +1,4 @@
+import itertools
 from dataclasses import dataclass
 
 from bluesky.run_engine import RunEngineStateMachine
@@ -6,8 +7,13 @@ from pydantic import BaseModel
 
 from blueapi.core.bluesky_types import Plan
 from blueapi.service.handler import Handler
+<<<<<<< HEAD
 from blueapi.worker.task import RunPlan
 from src.blueapi.worker import WorkerState
+=======
+from blueapi.service.model import TaskResponse
+from blueapi.worker.task import RunPlan, Task
+>>>>>>> 715ace60 (Fix tests)
 
 
 def test_get_plans(handler: Handler, client: TestClient) -> None:

--- a/tests/service/test_rest_api.py
+++ b/tests/service/test_rest_api.py
@@ -6,8 +6,7 @@ from pydantic import BaseModel
 
 from blueapi.core.bluesky_types import Plan
 from blueapi.service.handler import Handler
-from blueapi.service.model import TaskResponse
-from blueapi.worker.task import RunPlan, Task
+from blueapi.worker.task import RunPlan
 from src.blueapi.worker import WorkerState
 
 

--- a/tests/service/test_rest_api.py
+++ b/tests/service/test_rest_api.py
@@ -81,9 +81,9 @@ def test_put_plan_submits_task(handler: Handler, client: TestClient) -> None:
 
     client.put(f"/task/{task_name}", json=task_json)
 
-    task_queue = handler.worker._task_queue.queue  # type: ignore
-    assert len(task_queue) == 1
-    assert task_queue[0].task == RunPlan(name=task_name, params=task_json)
+    assert handler.worker.get_pending_tasks()[0].task == RunPlan(
+        name=task_name, params=task_json
+    )
 
 
 def test_get_state_updates(handler: Handler, client: TestClient) -> None:

--- a/tests/service/test_rest_api.py
+++ b/tests/service/test_rest_api.py
@@ -1,4 +1,3 @@
-import itertools
 from dataclasses import dataclass
 
 from bluesky.run_engine import RunEngineStateMachine
@@ -7,13 +6,9 @@ from pydantic import BaseModel
 
 from blueapi.core.bluesky_types import Plan
 from blueapi.service.handler import Handler
-<<<<<<< HEAD
-from blueapi.worker.task import RunPlan
-from src.blueapi.worker import WorkerState
-=======
 from blueapi.service.model import TaskResponse
 from blueapi.worker.task import RunPlan, Task
->>>>>>> 715ace60 (Fix tests)
+from src.blueapi.worker import WorkerState
 
 
 def test_get_plans(handler: Handler, client: TestClient) -> None:

--- a/tests/worker/test_reworker.py
+++ b/tests/worker/test_reworker.py
@@ -186,6 +186,11 @@ def test_no_additional_progress_events_after_complete(worker: Worker):
     assert "STATUS_AFTER_FINISH" not in display_names
 
 
+#
+# Worker helpers
+#
+
+
 def assert_run_produces_worker_events(
     expected_events: List[WorkerEvent],
     worker: Worker,
@@ -206,6 +211,11 @@ def begin_task_and_wait_until_complete(
 
     worker.begin_task(task_id)
     return events.result(timeout=timeout)
+
+
+#
+# Event stream helpers
+#
 
 
 E = TypeVar("E")

--- a/tests/worker/test_reworker.py
+++ b/tests/worker/test_reworker.py
@@ -102,13 +102,12 @@ def test_stop_with_task_pending(inert_worker: Worker) -> None:
 def test_clear_task(worker: Worker) -> None:
     task_id = worker.submit_task(_SIMPLE_TASK)
     assert worker.get_pending_tasks() == [_SIMPLE_TASK]
-    worker.clear_task(task_id)
+    assert worker.clear_task(task_id)
     assert worker.get_pending_tasks() == []
 
 
 def test_clear_nonexistant_task(worker: Worker) -> None:
-    with pytest.raises(KeyError):
-        worker.clear_task("foo")
+    assert not worker.clear_task("foo")
 
 
 @pytest.mark.parametrize("num_runs", [2, 3, 4])

--- a/tests/worker/test_reworker.py
+++ b/tests/worker/test_reworker.py
@@ -110,11 +110,13 @@ def test_clear_nonexistant_task(worker: Worker) -> None:
     assert not worker.clear_task("foo")
 
 
-@pytest.mark.parametrize("num_runs", [2, 3, 4])
 def test_does_not_allow_simultaneous_running_tasks(
-    worker: Worker, stop_plan: asyncio.Event, num_runs: int
+    worker: Worker, stop_plan: asyncio.Event
 ) -> None:
-    task_ids = [worker.submit_task(_INDEFINITE_TASK) for _ in range(num_runs)]
+    task_ids = [
+        worker.submit_task(_INDEFINITE_TASK),
+        worker.submit_task(_INDEFINITE_TASK),
+    ]
     with pytest.raises(WorkerBusyError):
         try:
             for task_id in task_ids:
@@ -125,7 +127,7 @@ def test_does_not_allow_simultaneous_running_tasks(
             stop_plan.set()
 
 
-@pytest.mark.parametrize("num_runs", [0, 1, 2, 3])
+@pytest.mark.parametrize("num_runs", [0, 1, 2])
 def test_produces_worker_events(worker: Worker, num_runs: int) -> None:
     task_ids = [worker.submit_task(_SIMPLE_TASK) for _ in range(num_runs)]
     event_sequences = [_sleep_events(task_id) for task_id in task_ids]

--- a/tests/worker/test_reworker.py
+++ b/tests/worker/test_reworker.py
@@ -139,7 +139,7 @@ def _sleep_events(task_id: str) -> List[WorkerEvent]:
         WorkerEvent(
             state=WorkerState.RUNNING,
             task_status=TaskStatus(
-                task_name=task_id, task_complete=False, task_failed=False
+                task_id=task_id, task_complete=False, task_failed=False
             ),
             errors=[],
             warnings=[],
@@ -147,7 +147,7 @@ def _sleep_events(task_id: str) -> List[WorkerEvent]:
         WorkerEvent(
             state=WorkerState.IDLE,
             task_status=TaskStatus(
-                task_name=task_id, task_complete=False, task_failed=False
+                task_id=task_id, task_complete=False, task_failed=False
             ),
             errors=[],
             warnings=[],
@@ -155,7 +155,7 @@ def _sleep_events(task_id: str) -> List[WorkerEvent]:
         WorkerEvent(
             state=WorkerState.IDLE,
             task_status=TaskStatus(
-                task_name=task_id, task_complete=True, task_failed=False
+                task_id=task_id, task_complete=True, task_failed=False
             ),
             errors=[],
             warnings=[],

--- a/tests/worker/test_reworker.py
+++ b/tests/worker/test_reworker.py
@@ -115,10 +115,34 @@ def test_submit_multiple_tasks(worker: Worker) -> None:
     ]
 
 
-def test_submit_before_start_pending(inert_worker: Worker) -> None:
+def test_stop_with_task_pending(inert_worker: Worker) -> None:
     inert_worker.start()
     inert_worker.submit_task(_SIMPLE_TASK)
     inert_worker.stop()
+
+
+def test_restart_leaves_task_pending(worker: Worker) -> None:
+    task_id = worker.submit_task(_SIMPLE_TASK)
+    assert worker.get_pending_tasks() == [
+        TrackableTask(task_id=task_id, task=_SIMPLE_TASK)
+    ]
+    worker.stop()
+    worker.start()
+    assert worker.get_pending_tasks() == [
+        TrackableTask(task_id=task_id, task=_SIMPLE_TASK)
+    ]
+
+
+def test_submit_before_start_pending(inert_worker: Worker) -> None:
+    task_id = inert_worker.submit_task(_SIMPLE_TASK)
+    inert_worker.start()
+    assert inert_worker.get_pending_tasks() == [
+        TrackableTask(task_id=task_id, task=_SIMPLE_TASK)
+    ]
+    inert_worker.stop()
+    assert inert_worker.get_pending_tasks() == [
+        TrackableTask(task_id=task_id, task=_SIMPLE_TASK)
+    ]
 
 
 def test_clear_task(worker: Worker) -> None:

--- a/tests/worker/test_reworker.py
+++ b/tests/worker/test_reworker.py
@@ -176,7 +176,7 @@ def test_no_additional_progress_events_after_complete(worker: Worker):
         name="move", params={"moves": {"additional_status_device": 5.0}}
     )
     task_id = worker.submit_task(task)
-    submit_task_and_wait_until_complete(worker, task_id)
+    begin_task_and_wait_until_complete(worker, task_id)
 
     # Extract all the display_name fields from the events
     list_of_dict_keys = [pe.statuses.values() for pe in progress_events]
@@ -191,10 +191,10 @@ def assert_run_produces_worker_events(
     worker: Worker,
     task_id: str,
 ) -> None:
-    assert submit_task_and_wait_until_complete(worker, task_id) == expected_events
+    assert begin_task_and_wait_until_complete(worker, task_id) == expected_events
 
 
-def submit_task_and_wait_until_complete(
+def begin_task_and_wait_until_complete(
     worker: Worker,
     task_id: str,
     timeout: float = 5.0,

--- a/tests/worker/test_reworker.py
+++ b/tests/worker/test_reworker.py
@@ -1,6 +1,5 @@
 import asyncio
 import itertools
-import time
 from concurrent.futures import Future
 from typing import Callable, Iterable, List, Optional, TypeVar
 

--- a/tests/worker/test_reworker.py
+++ b/tests/worker/test_reworker.py
@@ -115,7 +115,7 @@ def test_submit_multiple_tasks(worker: Worker) -> None:
     ]
 
 
-def test_stop_with_task_pending(inert_worker: Worker) -> None:
+def test_submit_before_start_pending(inert_worker: Worker) -> None:
     inert_worker.start()
     inert_worker.submit_task(_SIMPLE_TASK)
     inert_worker.stop()


### PR DESCRIPTION
Draft PR with a suggested transaction mode for the worker, transaction mode enables creating of new tasks before they are submitted.

To consider:
* Is the transaction API right?
* Should we allow multiple pending transactions or only one at a time? Currently we lock the transaction mode if one is in progress.
* Can the implementation be simplified? (probably yes)
* Should we still allow non-transaction plan running? (probably not, as it provides a way around the aforementioned transaction lockout)