### PR TITLE
Track completed statuses (#111)

### DIFF
--- a/tests/worker/devices.py
+++ b/tests/worker/devices.py
@@ -1,0 +1,48 @@
+# Devices to use for worker tests
+
+from bluesky.protocols import Movable, Status
+from ophyd import Device, DeviceStatus
+
+
+class AdditionalUpdateStatus(DeviceStatus):
+    """
+    Status which emits an additional update to watchers
+    after the status is finished.
+    """
+
+    def add_callback(self, callback):
+        retval = super().add_callback(callback)
+        return retval
+
+    def watch(self, func):
+        """
+        set_finished called here instead of add_callback
+        to prevent race conditions
+        """
+        self.set_finished()
+        return super().watch(func)
+
+    def _run_callbacks(self) -> None:
+        super()._run_callbacks()
+        for watcher in self._watchers:
+            watcher(
+                name="STATUS_AFTER_FINISH",
+                current=0.0,
+                initial=1.0,
+                target=2.0,
+                unit="kg",
+                precision=0,
+                fraction=0.5,
+                time_elapsed=1.0,
+                time_remaining=1.0,
+            )
+
+
+class AdditionalStatusDevice(Device, Movable):
+    def set(self, value: float) -> Status:
+        status = AdditionalUpdateStatus(self)
+        return status
+
+
+def additional_status_device(name="additional_status_device") -> AdditionalStatusDevice:
+    return AdditionalStatusDevice(name=name)

--- a/tests/worker/test_reworker.py
+++ b/tests/worker/test_reworker.py
@@ -4,7 +4,7 @@ from typing import Callable, Iterable, List, Optional, TypeVar
 
 import pytest
 
-from blueapi.config import EnvironmentConfig
+from blueapi.config import EnvironmentConfig, Source, SourceKind
 from blueapi.core import BlueskyContext, EventStream
 from blueapi.worker import (
     RunEngineWorker,
@@ -15,13 +15,18 @@ from blueapi.worker import (
     WorkerEvent,
     WorkerState,
 )
+from blueapi.worker.event import ProgressEvent
 from blueapi.worker.worker_busy_error import WorkerBusyError
 
 
 @pytest.fixture
 def context() -> BlueskyContext:
     ctx = BlueskyContext()
-    ctx.with_config(EnvironmentConfig())
+    ctx_config = EnvironmentConfig()
+    ctx_config.sources.append(
+        Source(kind=SourceKind.DEVICE_FUNCTIONS, module="devices")
+    )
+    ctx.with_config(ctx_config)
     return ctx
 
 


### PR DESCRIPTION
For some devices there may be an additional status update broadcast after the on_complete callback. This causes the status to be added back to the dictionary where it will never be removed.

Track which statuses have been completed and check this set when updating to ensure that a completed status is never added back to the snapshot after on_complete is called.