### PR TITLE
Make run plan parameters an argument

### DIFF
--- a/src/blueapi/cli/cli.py
+++ b/src/blueapi/cli/cli.py
@@ -95,11 +95,12 @@ def get_devices(obj: dict) -> None:
 
 @controller.command(name="run")
 @click.argument("name", type=str)
-@click.option("-p", "--parameters", type=str, help="Parameters as valid JSON")
+@click.argument("parameters", type=str, required=False)
 @check_connection
 @click.pass_obj
-def run_plan(obj: dict, name: str, parameters: str) -> None:
+def run_plan(obj: dict, name: str, parameters: Optional[str]) -> None:
     config: ApplicationConfig = obj["config"]
+    parameters = parameters or "{}"
 
     resp = requests.put(
         f"http://{config.api.host}:{config.api.port}/task/{name}",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -165,7 +165,7 @@ def test_config_passed_down_to_command_children(
     mock_requests.return_value = Mock()
 
     runner.invoke(
-        main, ["-c", config_path, "controller", "run", "sleep", "-p", '{"time": 5}']
+        main, ["-c", config_path, "controller", "run", "sleep", '{"time": 5}']
     )
 
     assert mock_requests.call_args[0][0] == "http://a.fake.host:12345/task/sleep"


### PR DESCRIPTION
Instead of an option that is required in every call. If no parameters are passed,
default to empty dict.
