### PR TITLE
Copy subscriptions before iteration

### DIFF
--- a/src/blueapi/core/event.py
+++ b/src/blueapi/core/event.py
@@ -75,5 +75,5 @@ class EventPublisher(EventStream[E, int]):
                 event with other events
         """
 
-        for callback in self._subscriptions.values():
+        for callback in list(self._subscriptions.values()):
             callback(event, correlation_id)


### PR DESCRIPTION
This ensures that if a callback modifies the dictionary there is no 'dictionary changed size during iteration' error.