### PR TITLE
Consume information about failed device instantiation and expose information to REST API

### DIFF
--- a/src/blueapi/service/main.py
+++ b/src/blueapi/service/main.py
@@ -7,7 +7,14 @@ from blueapi.config import ApplicationConfig
 from blueapi.worker import RunPlan
 
 from .handler import Handler, get_handler, setup_handler, teardown_handler
-from .model import DeviceModel, DeviceResponse, PlanModel, PlanResponse, TaskResponse
+from .model import (
+    DeviceModel,
+    DeviceResponse,
+    FailedDeviceInstantiation,
+    PlanModel,
+    PlanResponse,
+    TaskResponse,
+)
 
 
 @asynccontextmanager
@@ -50,7 +57,11 @@ def get_devices(handler: Handler = Depends(get_handler)):
         devices=[
             DeviceModel.from_device(device)
             for device in handler.context.devices.values()
-        ]
+        ],
+        failed_devices=[
+            FailedDeviceInstantiation.from_exception_informations(k, v)
+            for k, v in handler.context.failed_devices.items()
+        ],
     )
 
 

--- a/src/blueapi/service/model.py
+++ b/src/blueapi/service/model.py
@@ -1,6 +1,8 @@
-from typing import Iterable, List
+from enum import Enum
+from typing import Iterable, List, Mapping, Type, Union
 
 from bluesky.protocols import HasName
+from dodal.utils import DependentDeviceInstantiationException, ExceptionInformation
 from pydantic import Field
 
 from blueapi.core import BLUESKY_PROTOCOLS, Device, Plan
@@ -9,26 +11,63 @@ from blueapi.utils import BlueapiBaseModel
 _UNKNOWN_NAME = "UNKNOWN"
 
 
-class DeviceModel(BlueapiBaseModel):
+class _DeviceInformation(BlueapiBaseModel):
+    device_type: type[Device] = Field(description="Concrete type of the device")
+    protocols: List[str] = Field(
+        description="Protocols that a device conforms to, indicating its capabilities"
+    )
+
+
+class DeviceModel(_DeviceInformation):
     """
     Representation of a device
     """
 
     name: str = Field(description="Name of the device")
-    protocols: List[str] = Field(
-        description="Protocols that a device conforms to, indicating its capabilities"
-    )
 
     @classmethod
     def from_device(cls, device: Device) -> "DeviceModel":
         name = device.name if isinstance(device, HasName) else _UNKNOWN_NAME
-        return cls(name=name, protocols=list(_protocol_names(device)))
+        return cls(
+            name=name, protocols=list(_protocol_names(device)), device_type=type(device)
+        )
 
 
-def _protocol_names(device: Device) -> Iterable[str]:
-    for protocol in BLUESKY_PROTOCOLS:
-        if isinstance(device, protocol):
-            yield protocol.__name__
+class FailedDeviceInstantiation(_DeviceInformation):
+    """
+    Representation of a device that either failed to be instantiated or was not
+    attempted due to an earlier failure.
+    """
+
+    factory_name: str = Field(
+        description="Name of a factory method that was not successfully called"
+    )
+    exception: Union[str, Mapping[str, str]] = Field(
+        description="The exception that prevented this method from completing or a "
+        "mapping of the name of factory methods that this method depended on to "
+        "the exception that caused them to fail"
+    )
+
+    @classmethod
+    def from_exception_informations(
+        cls, factory_name: str, exc: ExceptionInformation
+    ) -> "FailedDeviceInstantiation":
+        exception = exc.exception
+        exception_info: Union[str, Mapping[str, str]]
+        if isinstance(exception, DependentDeviceInstantiationException):
+            exception_info = {str(k): str(v) for k, v in exception.exceptions.values()}
+        else:
+            exception_info = f"{type(exception)}: {exception}"
+        return cls(
+            factory_name=factory_name,
+            device_type=exc.return_type,
+            protocols=list(_protocol_names(exc.return_type)),
+            exception=exception_info,
+        )
+
+
+def _protocol_names(device: Union[Device, Type[Device]]) -> Iterable[str]:
+    yield from (prot.__name__ for prot in BLUESKY_PROTOCOLS if isinstance(device, prot))
 
 
 class DeviceRequest(BlueapiBaseModel):
@@ -45,6 +84,9 @@ class DeviceResponse(BlueapiBaseModel):
     """
 
     devices: List[DeviceModel] = Field(description="Devices available to use in plans")
+    failed_devices: List[FailedDeviceInstantiation] = Field(
+        description="Device creation methods that failed to run"
+    )
 
 
 class PlanModel(BlueapiBaseModel):

--- a/src/blueapi/startup/example_devices.py
+++ b/src/blueapi/startup/example_devices.py
@@ -1,4 +1,5 @@
 from ophyd.sim import Syn2DGauss, SynGauss, SynSignal
+from ophyd.utils import DisconnectedError
 
 from .simmotor import BrokenSynAxis, SynAxisWithMotionEvents
 
@@ -72,3 +73,7 @@ def current_det(
         Imax=1,
         labels={"detectors"},
     )
+
+
+def disconnected_device(name="disconnected_device") -> SynGauss:
+    raise DisconnectedError

--- a/tests/core/fake_device_module.py
+++ b/tests/core/fake_device_module.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock
 
 from ophyd import EpicsMotor
+from ophyd.utils import DisconnectedError
 
 
 def fake_motor_bundle_b(
@@ -23,6 +24,10 @@ def fake_motor_bundle_a(
     fake_motor_y: EpicsMotor,
 ) -> EpicsMotor:
     return _mock_with_name("motor_bundle_a")
+
+
+def disconnected_motor() -> EpicsMotor:
+    raise DisconnectedError
 
 
 def _mock_with_name(name: str) -> MagicMock:


### PR DESCRIPTION
Requires https://github.com/DiamondLightSource/dodal/pull/62 to be merged.

Part of #198, as allows start up when not all devices are connected (desired behaviour replacing plan setups)