### PR TITLE
Standardise api

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -21,6 +21,8 @@ metadata:
   name: blueapiControl
   title: Athena BlueAPI Control
   description: REST API for getting plans/devices from the worker (and running tasks)
+  annotations:
+    diamond.ac.uk/viewdocs-url: https://diamondlightsource.github.io/blueapi
 spec:
   type: openapi
   lifecycle: production

--- a/docs/user/reference/openapi.yaml
+++ b/docs/user/reference/openapi.yaml
@@ -134,7 +134,7 @@ components:
       type: string
 info:
   title: BlueAPI Control
-  version: 0.2.2
+  version: 0.0.2
 openapi: 3.0.2
 paths:
   /devices:

--- a/docs/user/reference/openapi.yaml
+++ b/docs/user/reference/openapi.yaml
@@ -68,6 +68,22 @@ components:
       - plans
       title: PlanResponse
       type: object
+    RunPlan:
+      additionalProperties: false
+      description: Task that will run a plan
+      properties:
+        name:
+          description: Name of plan to run
+          title: Name
+          type: string
+        params:
+          description: Values for parameters to plan, if any
+          title: Params
+          type: object
+      required:
+      - name
+      title: RunPlan
+      type: object
     TaskResponse:
       additionalProperties: false
       description: Acknowledgement that a task has started, includes its ID
@@ -118,13 +134,25 @@ components:
       type: string
 info:
   title: BlueAPI Control
-  version: 0.1.0
+  version: 0.2.2
 openapi: 3.0.2
 paths:
-  /device/{name}:
+  /devices:
+    get:
+      description: Retrieve information about all available devices.
+      operationId: get_devices_devices_get
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeviceResponse'
+          description: Successful Response
+      summary: Get Devices
+  /devices/{name}:
     get:
       description: Retrieve information about a devices by its (unique) name.
-      operationId: get_device_by_name_device__name__get
+      operationId: get_device_by_name_devices__name__get
       parameters:
       - in: path
         name: name
@@ -146,22 +174,22 @@ paths:
                 $ref: '#/components/schemas/HTTPValidationError'
           description: Validation Error
       summary: Get Device By Name
-  /devices:
+  /plans:
     get:
-      description: Retrieve information about all available devices.
-      operationId: get_devices_devices_get
+      description: Retrieve information about all available plans.
+      operationId: get_plans_plans_get
       responses:
         '200':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DeviceResponse'
+                $ref: '#/components/schemas/PlanResponse'
           description: Successful Response
-      summary: Get Devices
-  /plan/{name}:
+      summary: Get Plans
+  /plans/{name}:
     get:
       description: Retrieve information about a plan by its (unique) name.
-      operationId: get_plan_by_name_plan__name__get
+      operationId: get_plan_by_name_plans__name__get
       parameters:
       - in: path
         name: name
@@ -183,41 +211,23 @@ paths:
                 $ref: '#/components/schemas/HTTPValidationError'
           description: Validation Error
       summary: Get Plan By Name
-  /plans:
-    get:
-      description: Retrieve information about all available plans.
-      operationId: get_plans_plans_get
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PlanResponse'
-          description: Successful Response
-      summary: Get Plans
-  /task/{name}:
-    put:
-      description: Submit a task onto the worker queue.
-      operationId: submit_task_task__name__put
-      parameters:
-      - in: path
-        name: name
-        required: true
-        schema:
-          title: Name
-          type: string
+  /tasks:
+    post:
+      description: Submit a task to the worker.
+      operationId: submit_task_tasks_post
       requestBody:
         content:
           application/json:
             example:
-              detectors:
-              - x
+              name: count
+              params:
+                detectors:
+                - x
             schema:
-              title: Task
-              type: object
+              $ref: '#/components/schemas/RunPlan'
         required: true
       responses:
-        '200':
+        '201':
           content:
             application/json:
               schema:

--- a/src/blueapi/config.py
+++ b/src/blueapi/config.py
@@ -56,6 +56,7 @@ class LoggingConfig(BlueapiBaseModel):
 class RestConfig(BlueapiBaseModel):
     host: str = "localhost"
     port: int = 8000
+    version: str = "0.0.2"
 
 
 class ApplicationConfig(BlueapiBaseModel):

--- a/src/blueapi/config.py
+++ b/src/blueapi/config.py
@@ -56,7 +56,6 @@ class LoggingConfig(BlueapiBaseModel):
 class RestConfig(BlueapiBaseModel):
     host: str = "localhost"
     port: int = 8000
-    version: str = "0.0.2"
 
 
 class ApplicationConfig(BlueapiBaseModel):

--- a/src/blueapi/service/main.py
+++ b/src/blueapi/service/main.py
@@ -1,5 +1,4 @@
 from contextlib import asynccontextmanager
-from typing import Mapping
 
 from fastapi import Body, Depends, FastAPI, HTTPException, Request, Response
 
@@ -83,13 +82,7 @@ def submit_task(
 
 
 @app.get("/worker/state")
-async def get_state(handler: Handler = Depends(get_handler)) -> WorkerState:
-    """Get the State of the Worker"""
-    return handler.worker.state
-
-
-@app.get("/worker/state")
-async def get_state(handler: Handler = Depends(get_handler)) -> WorkerState:
+def get_state(handler: Handler = Depends(get_handler)) -> WorkerState:
     """Get the State of the Worker"""
     return handler.worker.state
 

--- a/src/blueapi/service/main.py
+++ b/src/blueapi/service/main.py
@@ -9,6 +9,8 @@ from blueapi.worker import RunPlan, WorkerState
 from .handler import Handler, get_handler, setup_handler, teardown_handler
 from .model import DeviceModel, DeviceResponse, PlanModel, PlanResponse, TaskResponse
 
+REST_API_VERSION = "0.2.2"
+
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -23,34 +25,32 @@ app = FastAPI(
     on_shutdown=[teardown_handler],
     title="BlueAPI Control",
     lifespan=lifespan,
+    version=REST_API_VERSION,
 )
 
 
 @app.get("/plans", response_model=PlanResponse)
-async def get_plans(response: Response, handler: Handler = Depends(get_handler)):
+def get_plans(response: Response, handler: Handler = Depends(get_handler)):
     """Retrieve information about all available plans."""
-    add_response_headers(response)
     return PlanResponse(
         plans=[PlanModel.from_plan(plan) for plan in handler.context.plans.values()]
     )
 
 
 @app.get("/plans/{name}", response_model=PlanModel)
-async def get_plan_by_name(
+def get_plan_by_name(
     response: Response, name: str, handler: Handler = Depends(get_handler)
 ):
     """Retrieve information about a plan by its (unique) name."""
     try:
-        add_response_headers(response)
         return PlanModel.from_plan(handler.context.plans[name])
     except KeyError:
         raise HTTPException(status_code=404, detail="Item not found")
 
 
 @app.get("/devices", response_model=DeviceResponse)
-async def get_devices(response: Response, handler: Handler = Depends(get_handler)):
+def get_devices(response: Response, handler: Handler = Depends(get_handler)):
     """Retrieve information about all available devices."""
-    add_response_headers(response)
     return DeviceResponse(
         devices=[
             DeviceModel.from_device(device)
@@ -60,19 +60,18 @@ async def get_devices(response: Response, handler: Handler = Depends(get_handler
 
 
 @app.get("/devices/{name}", response_model=DeviceModel)
-async def get_device_by_name(
+def get_device_by_name(
     response: Response, name: str, handler: Handler = Depends(get_handler)
 ):
     """Retrieve information about a devices by its (unique) name."""
     try:
-        add_response_headers(response)
         return DeviceModel.from_device(handler.context.devices[name])
     except KeyError:
         raise HTTPException(status_code=404, detail="Item not found")
 
 
 @app.post("/tasks", response_model=TaskResponse, status_code=201)
-async def submit_task(
+def submit_task(
     request: Request,
     response: Response,
     task: RunPlan = Body(
@@ -82,9 +81,15 @@ async def submit_task(
 ):
     """Submit a task to the worker."""
     task_id: str = handler.worker.submit_task(task)
-    add_response_headers(response, {"Location": f"{request.url}/{task_id}"})
+    response.headers["Location"] = f"{request.url}/{task_id}"
     handler.worker.begin_task(task_id)
     return TaskResponse(task_id=task_id)
+
+
+@app.get("/worker/state")
+async def get_state(handler: Handler = Depends(get_handler)) -> WorkerState:
+    """Get the State of the Worker"""
+    return handler.worker.state
 
 
 @app.get("/worker/state")
@@ -97,12 +102,11 @@ def start(config: ApplicationConfig):
     import uvicorn
 
     app.state.config = config
-    app.version = config.api.version
     uvicorn.run(app, host=config.api.host, port=config.api.port)
 
 
-def add_response_headers(
-    response: Response, extra_headers: Mapping[str, str] = {}
-) -> None:
-    response.headers.update({"X-API-Version": app.version})
-    response.headers.update(extra_headers)
+@app.middleware("http")
+async def add_api_version_header(request: Request, call_next):
+    response = await call_next(request)
+    response.headers["X-API-Version"] = REST_API_VERSION
+    return response

--- a/src/blueapi/service/main.py
+++ b/src/blueapi/service/main.py
@@ -9,7 +9,7 @@ from blueapi.worker import RunPlan, WorkerState
 from .handler import Handler, get_handler, setup_handler, teardown_handler
 from .model import DeviceModel, DeviceResponse, PlanModel, PlanResponse, TaskResponse
 
-REST_API_VERSION = "0.2.2"
+REST_API_VERSION = "0.0.2"
 
 
 @asynccontextmanager

--- a/src/blueapi/service/main.py
+++ b/src/blueapi/service/main.py
@@ -30,7 +30,7 @@ app = FastAPI(
 
 
 @app.get("/plans", response_model=PlanResponse)
-def get_plans(response: Response, handler: Handler = Depends(get_handler)):
+def get_plans(handler: Handler = Depends(get_handler)):
     """Retrieve information about all available plans."""
     return PlanResponse(
         plans=[PlanModel.from_plan(plan) for plan in handler.context.plans.values()]
@@ -38,9 +38,7 @@ def get_plans(response: Response, handler: Handler = Depends(get_handler)):
 
 
 @app.get("/plans/{name}", response_model=PlanModel)
-def get_plan_by_name(
-    response: Response, name: str, handler: Handler = Depends(get_handler)
-):
+def get_plan_by_name(name: str, handler: Handler = Depends(get_handler)):
     """Retrieve information about a plan by its (unique) name."""
     try:
         return PlanModel.from_plan(handler.context.plans[name])
@@ -49,7 +47,7 @@ def get_plan_by_name(
 
 
 @app.get("/devices", response_model=DeviceResponse)
-def get_devices(response: Response, handler: Handler = Depends(get_handler)):
+def get_devices(handler: Handler = Depends(get_handler)):
     """Retrieve information about all available devices."""
     return DeviceResponse(
         devices=[
@@ -60,9 +58,7 @@ def get_devices(response: Response, handler: Handler = Depends(get_handler)):
 
 
 @app.get("/devices/{name}", response_model=DeviceModel)
-def get_device_by_name(
-    response: Response, name: str, handler: Handler = Depends(get_handler)
-):
+def get_device_by_name(name: str, handler: Handler = Depends(get_handler)):
     """Retrieve information about a devices by its (unique) name."""
     try:
         return DeviceModel.from_device(handler.context.devices[name])

--- a/tests/service/test_rest_api.py
+++ b/tests/service/test_rest_api.py
@@ -30,7 +30,7 @@ def test_get_plan_by_name(handler: Handler, client: TestClient) -> None:
     plan = Plan(name="my-plan", model=MyModel)
 
     handler.context.plans = {"my-plan": plan}
-    response = client.get("/plan/my-plan")
+    response = client.get("/plans/my-plan")
 
     assert response.status_code == 200
     assert response.json() == {"name": "my-plan"}
@@ -65,7 +65,7 @@ def test_get_device_by_name(handler: Handler, client: TestClient) -> None:
     device = MyDevice("my-device")
 
     handler.context.devices = {"my-device": device}
-    response = client.get("/device/my-device")
+    response = client.get("/devices/my-device")
 
     assert response.status_code == 200
     assert response.json() == {
@@ -75,13 +75,13 @@ def test_get_device_by_name(handler: Handler, client: TestClient) -> None:
 
 
 def test_put_plan_submits_task(handler: Handler, client: TestClient) -> None:
-    task_json = {"detectors": ["x"]}
     task_name = "count"
+    task_json = {"name": task_name, "params": {"detectors": ["x"]}}
 
-    client.put(f"/task/{task_name}", json=task_json)
+    client.post("/tasks", json=task_json)
 
     assert handler.worker.get_pending_tasks()[0].task == RunPlan(
-        name=task_name, params=task_json
+        name=task_name, params=task_json["params"]
     )
 
 

--- a/tests/service/test_rest_api.py
+++ b/tests/service/test_rest_api.py
@@ -76,12 +76,13 @@ def test_get_device_by_name(handler: Handler, client: TestClient) -> None:
 
 def test_put_plan_submits_task(handler: Handler, client: TestClient) -> None:
     task_name = "count"
-    task_json = {"name": task_name, "params": {"detectors": ["x"]}}
+    task_params = {"detectors": ["x"]}
+    task_json = {"name": task_name, "params": task_params}
 
     client.post("/tasks", json=task_json)
 
     assert handler.worker.get_pending_tasks()[0].task == RunPlan(
-        name=task_name, params=task_json["params"]
+        name=task_name, params=task_params
     )
 
 


### PR DESCRIPTION
Rework the existing endpoints to comply with the guidelines:

- Making url object elements plural
- Changing PUT to POST for task creation
- Returning 201 for successful task creation
- Returning Location header of created resource on successful creation
- Adding version header to all endpoint responses

API version is set in app declaration after loading it from REST config object.
Added function to allow easy appending of endpoint specific response headers to defaults
Submit task method refactored to return task id (currently UUID)