### PR TITLE
Pin typing extensions module to <4.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "uvicorn",
     "requests",
     "dodal @ git+https://github.com/DiamondLightSource/dodal.git",
-
+    "typing_extensions<4.6",
 ]
 dynamic = ["version"]
 license.file = "LICENSE"


### PR DESCRIPTION
4.6 is causing various issues with protocols and pydantic, see https://github.com/pydantic/pydantic/issues/5821