### PR TITLE
Include errors in current task and synchronise on begin_task

### DIFF
--- a/docs/user/reference/openapi.yaml
+++ b/docs/user/reference/openapi.yaml
@@ -100,13 +100,14 @@ components:
       additionalProperties: false
       description: A representation of a task that the worker recognizes
       properties:
+        errors:
+          items:
+            type: string
+          title: Errors
+          type: array
         isComplete:
           default: false
           title: Iscomplete
-          type: boolean
-        isError:
-          default: false
-          title: Iserror
           type: boolean
         isPending:
           default: true

--- a/src/blueapi/worker/reworker.py
+++ b/src/blueapi/worker/reworker.py
@@ -119,6 +119,9 @@ class RunEngineWorker(Worker[Task]):
         return task_id
 
     def _submit_trackable_task(self, trackable_task: TrackableTask) -> None:
+        if self.state is not WorkerState.IDLE:
+            raise WorkerBusyError(f"Worker is in state {self.state}")
+
         task_started = Event()
 
         def mark_task_as_started(event: WorkerEvent, _: Optional[str]) -> None:

--- a/src/blueapi/worker/reworker.py
+++ b/src/blueapi/worker/reworker.py
@@ -119,12 +119,27 @@ class RunEngineWorker(Worker[Task]):
         return task_id
 
     def _submit_trackable_task(self, trackable_task: TrackableTask) -> None:
+        task_started = Event()
+
+        def mark_task_as_started(event: WorkerEvent, _: Optional[str]) -> None:
+            if (
+                event.task_status is not None
+                and event.task_status.task_id == trackable_task.task_id
+            ):
+                task_started.set()
+
         LOGGER.info(f"Submitting: {trackable_task}")
         try:
+            sub = self.worker_events.subscribe(mark_task_as_started)
             self._task_channel.put_nowait(trackable_task)
+            task_started.wait(timeout=5.0)
+            if not task_started.is_set():
+                raise TimeoutError("Failed to start plan within timeout")
         except Full:
             LOGGER.error("Cannot submit task while another is running")
             raise WorkerBusyError("Cannot submit task while another is running")
+        finally:
+            self.worker_events.unsubscribe(sub)
 
     def start(self) -> None:
         if self._started.is_set():
@@ -222,7 +237,7 @@ class RunEngineWorker(Worker[Task]):
     def _report_error(self, err: Exception) -> None:
         LOGGER.error(err, exc_info=True)
         if self._current is not None:
-            self._current.is_error = True
+            self._current.errors.append(str(err))
         self._errors.append(str(err))
 
     def _report_status(
@@ -235,7 +250,7 @@ class RunEngineWorker(Worker[Task]):
             task_status = TaskStatus(
                 task_id=self._current.task_id,
                 task_complete=self._current.is_complete,
-                task_failed=self._current.is_error or bool(errors),
+                task_failed=bool(self._current.errors),
             )
             correlation_id = self._current.task_id
         else:

--- a/src/blueapi/worker/worker.py
+++ b/src/blueapi/worker/worker.py
@@ -1,6 +1,8 @@
 from abc import ABC, abstractmethod
 from typing import Generic, List, Optional, TypeVar
 
+from pydantic import Field
+
 from blueapi.core import DataEvent, EventStream
 from blueapi.utils import BlueapiBaseModel
 
@@ -17,8 +19,8 @@ class TrackableTask(BlueapiBaseModel, Generic[T]):
     task_id: str
     task: T
     is_complete: bool = False
-    is_error: bool = False
     is_pending: bool = True
+    errors: List[str] = Field(default_factory=list)
 
 
 class Worker(ABC, Generic[T]):

--- a/tests/service/test_rest_api.py
+++ b/tests/service/test_rest_api.py
@@ -93,7 +93,9 @@ def test_put_plan_begins_task(handler: Handler, client: TestClient) -> None:
     task_json = {"task_id": task_id}
     client.put("/worker/task", json=task_json)
 
-    assert handler.worker.get_active_task().task_id == task_id
+    active_task = handler.worker.get_active_task()
+    assert active_task is not None
+    assert active_task.task_id == task_id
     handler.worker.stop()
 
 

--- a/tests/service/test_rest_api.py
+++ b/tests/service/test_rest_api.py
@@ -86,13 +86,15 @@ def test_create_task(handler: Handler, client: TestClient) -> None:
 
 
 def test_put_plan_begins_task(handler: Handler, client: TestClient) -> None:
+    handler.worker.start()
     response = client.post("/tasks", json=_TASK.dict())
     task_id = response.json()["taskId"]
 
     task_json = {"task_id": task_id}
     client.put("/worker/task", json=task_json)
 
-    assert handler.worker._task_channel.get().task_id == task_id  # type: ignore
+    assert handler.worker.get_active_task().task_id == task_id
+    handler.worker.stop()
 
 
 def test_get_state_updates(handler: Handler, client: TestClient) -> None:


### PR DESCRIPTION
Changes:

* Replace the `is_error` field on `TrackableTask` with `errors`, a list of strings
*  Include all errors generated while a task is active in its `errors`
* Synchronise `begin_task` so it blocks until the runner thread has set the active task, allows:

```python
worker.begin_task(my_id)
active = worker.get_active_task()
assert active.task_id == my_id
```