### PR TITLE
Make pytest work with server running

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -47,7 +47,7 @@ def test_main_with_nonexistent_config_file():
     type(result.exception) == FileNotFoundError
 
 
-@patch("requests.get")
+@patch("requests.request")
 def test_connection_error_caught_by_wrapper_func(mock_requests: Mock):
     mock_requests.side_effect = ConnectionError()
     runner = CliRunner()


### PR DESCRIPTION
Currently, if pytest is executed with a running server it will fail.

This fixes that - the reason it fails is because it actually makes a HTTP request. Previously, this was being patched, but there have been recent changes to how the CLI makes these requests.