### PR TITLE
Refactor validation

### DIFF
--- a/src/blueapi/worker/reworker.py
+++ b/src/blueapi/worker/reworker.py
@@ -176,9 +176,6 @@ class RunEngineWorker(Worker[Task]):
                 f"Worker did not stop within {self._start_stop_timeout} seconds"
             )
 
-        if not self._stopped.wait(timeout=self._stop_timeout):
-            raise TimeoutError("Did not receive successful stop signal!")
-
     @property
     def state(self) -> WorkerState:
         return self._state

--- a/src/blueapi/worker/reworker.py
+++ b/src/blueapi/worker/reworker.py
@@ -1,4 +1,5 @@
 import logging
+import time
 import uuid
 from dataclasses import dataclass
 from functools import partial
@@ -175,6 +176,9 @@ class RunEngineWorker(Worker[Task]):
             raise TimeoutError(
                 f"Worker did not stop within {self._start_stop_timeout} seconds"
             )
+
+        if not self._stopped.wait(timeout=self._stop_timeout):
+            raise TimeoutError("Did not receive successful stop signal!")
 
     @property
     def state(self) -> WorkerState:

--- a/src/blueapi/worker/reworker.py
+++ b/src/blueapi/worker/reworker.py
@@ -1,5 +1,4 @@
 import logging
-import time
 import uuid
 from dataclasses import dataclass
 from functools import partial

--- a/src/blueapi/worker/reworker.py
+++ b/src/blueapi/worker/reworker.py
@@ -25,7 +25,7 @@ from .event import (
     WorkerState,
 )
 from .multithread import run_worker_in_own_thread
-from .task import RunPlan, Task, _lookup_params
+from .task import Task
 from .worker import TrackableTask, Worker
 from .worker_busy_error import WorkerBusyError
 

--- a/src/blueapi/worker/reworker.py
+++ b/src/blueapi/worker/reworker.py
@@ -114,8 +114,7 @@ class RunEngineWorker(Worker[Task]):
             raise KeyError(f"No pending task with ID {task_id}")
 
     def submit_task(self, task: Task) -> str:
-        if isinstance(task, RunPlan):
-            task.set_clean_params(_lookup_params(self._ctx, task))
+        task.prepare_params(self._ctx)
         task_id: str = str(uuid.uuid4())
         trackable_task = TrackableTask(task_id=task_id, task=task)
         self._pending_tasks[task_id] = trackable_task

--- a/src/blueapi/worker/task.py
+++ b/src/blueapi/worker/task.py
@@ -37,10 +37,11 @@ class Task(BlueapiBaseModel):
         return self._prepared_params
 
 
+# Here for backward compatibility pending
+# https://github.com/DiamondLightSource/blueapi/issues/253
 class RunPlan(Task):
     """
-    Here for backward compatibility pending
-    https://github.com/DiamondLightSource/blueapi/issues/253
+    Task that will run a plan
     """
 
     ...

--- a/src/blueapi/worker/task.py
+++ b/src/blueapi/worker/task.py
@@ -7,27 +7,10 @@ from pydantic import BaseModel, Field
 from blueapi.core import BlueskyContext
 from blueapi.utils import BlueapiBaseModel
 
-
-# TODO: Make a TaggedUnion
-class Task(ABC, BlueapiBaseModel):
-    """
-    Object that can run with a TaskContext
-    """
-
-    @abstractmethod
-    def do_task(self, __ctx: BlueskyContext) -> None:
-        """
-        Perform the task using the context
-
-        Args:
-            ctx: Context for the task, holds plans/device/etc
-        """
-
-
 LOGGER = logging.getLogger(__name__)
 
 
-class RunPlan(Task):
+class Task(BlueapiBaseModel):
     """
     Task that will run a plan
     """
@@ -36,21 +19,35 @@ class RunPlan(Task):
     params: Mapping[str, Any] = Field(
         description="Values for parameters to plan, if any", default_factory=dict
     )
-    _sanitized_params: Optional[BaseModel] = Field(default=None)
+    _prepared_params: Optional[BaseModel] = None
 
-    def set_clean_params(self, model: BaseModel):
-        self._sanitized_params = model
+    def prepare_params(self, ctx: BlueskyContext) -> None:
+        self._ensure_params(ctx)
 
     def do_task(self, ctx: BlueskyContext) -> None:
         LOGGER.info(f"Asked to run plan {self.name} with {self.params}")
 
         func = ctx.plan_functions[self.name]
-        sanitized_params = self._sanitized_params or _lookup_params(ctx, self)
-        plan_generator = func(**sanitized_params.dict())
+        prepared_params = self._ensure_params(ctx)
+        plan_generator = func(**prepared_params.dict())
         ctx.run_engine(plan_generator)
 
+    def _ensure_params(self, ctx: BlueskyContext) -> BaseModel:
+        if self._prepared_params is None:
+            self._prepared_params = _lookup_params(ctx, self)
+        return self._prepared_params
 
-def _lookup_params(ctx: BlueskyContext, task: RunPlan) -> BaseModel:
+
+class RunPlan(Task):
+    """
+    Here for backward compatibility pending
+    https://github.com/DiamondLightSource/blueapi/issues/253
+    """
+
+    ...
+
+
+def _lookup_params(ctx: BlueskyContext, task: Task) -> BaseModel:
     """
     Checks plan parameters against context
 

--- a/src/blueapi/worker/task.py
+++ b/src/blueapi/worker/task.py
@@ -1,5 +1,4 @@
 import logging
-from abc import ABC, abstractmethod
 from typing import Any, Mapping, Optional
 
 from pydantic import BaseModel, Field


### PR DESCRIPTION
This is a refactor with no changes in behaviour. It was motivated by the fact that `RunEngineWorker` accessed the private function `_lookup_params` in `task.py`. 
* Deprecate `RunPlan` and move its functionality into `Task`
* Add method to `Task` that can optionally be called to cache the parameters, call it when run if not
* Remove instance check on task in worker as it is no longer needed