### PR TITLE
Fix race condition on worker stop/start

### DIFF
--- a/src/blueapi/worker/reworker.py
+++ b/src/blueapi/worker/reworker.py
@@ -151,9 +151,6 @@ class RunEngineWorker(Worker[Task]):
         if self._started.is_set():
             raise Exception("Worker is already running")
         self._wait_until_stopped()
-        assert self._stopped.is_set()
-        assert not self._stopping.is_set()
-        assert not self._started.is_set()
         run_worker_in_own_thread(self)
         self._wait_until_started()
 

--- a/tests/worker/test_reworker.py
+++ b/tests/worker/test_reworker.py
@@ -69,7 +69,7 @@ def context(fake_device: FakeDevice) -> BlueskyContext:
 
 @pytest.fixture
 def inert_worker(context: BlueskyContext) -> Worker[Task]:
-    return RunEngineWorker(context, stop_timeout=2.0)
+    return RunEngineWorker(context, start_stop_timeout=2.0)
 
 
 @pytest.fixture

--- a/tests/worker/test_reworker.py
+++ b/tests/worker/test_reworker.py
@@ -94,6 +94,13 @@ def test_multi_stop(inert_worker: Worker) -> None:
     inert_worker.stop()
 
 
+def test_restart(inert_worker: Worker) -> None:
+    inert_worker.start()
+    inert_worker.stop()
+    inert_worker.start()
+    inert_worker.stop()
+
+
 def test_multi_start(inert_worker: Worker) -> None:
     inert_worker.start()
     with pytest.raises(Exception):


### PR DESCRIPTION
The worker ensures that `worker.start()` blocks until the worker is ready to execute a task and `worker.stop()` blocks until the worker is no longer able to execute a task. It does so using a group of `threading.Event`s.

There were intermittent issues when events were not being cleaned up correctly, so when the worker was restarted it was not in the correct state. This PR fixes those and cleans up some of the thread control code.