### PR TITLE
Enable communication with rabbitmq using rabbitmq_stomp plugin

### DIFF
--- a/.github/enabled_plugins
+++ b/.github/enabled_plugins
@@ -1,0 +1,1 @@
+[rabbitmq_stomp]

--- a/.github/enabled_plugins
+++ b/.github/enabled_plugins
@@ -1,1 +1,0 @@
-[rabbitmq_stomp]

--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Lint
         run: tox -e pre-commit,mypy
 
-  test:
+  test-activemq:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
     strategy:
       fail-fast: false
@@ -72,7 +72,53 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:
-          name: ${{ matrix.python }}/${{ matrix.os }}
+          name: ${{ matrix.python }}/${{ matrix.os }}-activemq
+          files: cov.xml
+
+  test-rabbitmq:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-latest"] # can add windows-latest, macos-latest
+        python: ["3.9", "3.10", "3.11"]
+        install: [".[dev]", "-e .[dev]"]
+
+    runs-on: ${{ matrix.os }}
+    env:
+      # https://github.com/pytest-dev/pytest/issues/2042
+      PY_IGNORE_IMPORTMISMATCH: "1"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          # Need this to get version number from last tag
+          fetch-depth: 0
+
+      - name: Install python packages
+        uses: ./.github/actions/install_requirements
+        with:
+          python_version: ${{ matrix.python }}
+          requirements_file: requirements-test-${{ matrix.os }}-${{ matrix.python }}.txt
+          install_options: ${{ matrix.install }}
+
+      - name: List dependency tree
+        run: pipdeptree
+
+      - name: Start RabbitMQ
+        uses: namoshek/rabbitmq-github-action@v1
+        with:
+          ports: '61613:61613'
+          plugins: rabbitmq_stomp
+
+      - name: Run tests
+        run: pytest
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          name: ${{ matrix.python }}/${{ matrix.os }}-rabbitmq
           files: cov.xml
 
   dist:
@@ -112,7 +158,7 @@ jobs:
         run: python -m $(ls src | head -1) --version
 
   container:
-    needs: [lint, dist, test]
+    needs: [lint, dist, test-activemq, test-rabbitmq]
     runs-on: ubuntu-latest
 
     permissions:
@@ -173,7 +219,7 @@ jobs:
 
   release:
     # upload to PyPI and make a release on every tag
-    needs: [lint, dist, test]
+    needs: [lint, dist, test-activemq, test-rabbitmq]
     if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags') }}
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -35,8 +35,8 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest"] # can add windows-latest, macos-latest
-        python: ["3.9", "3.10", "3.11"]
-        install: [".[dev]", "-e .[dev]"]
+        python: ["3.11"]  # ["3.9", "3.10", "3.11"]
+        install: [".[dev]"]  # [".[dev]", "-e .[dev]"]
 
     services:
       activemq:
@@ -81,8 +81,8 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest"] # can add windows-latest, macos-latest
-        python: ["3.9", "3.10", "3.11"]
-        install: [".[dev]", "-e .[dev]"]
+        python: ["3.11"]  # ["3.9", "3.10", "3.11"]
+        install: [".[dev]"]  # [".[dev]", "-e .[dev]"]
 
     runs-on: ${{ matrix.os }}
     env:
@@ -90,6 +90,12 @@ jobs:
       PY_IGNORE_IMPORTMISMATCH: "1"
 
     steps:
+      - name: Start RabbitMQ
+        uses: namoshek/rabbitmq-github-action@v1
+        with:
+          ports: '61613:61613'
+          plugins: rabbitmq_stomp
+
       - name: Checkout
         uses: actions/checkout@v3
         with:
@@ -106,14 +112,11 @@ jobs:
       - name: List dependency tree
         run: pipdeptree
 
-      - name: Start RabbitMQ
-        uses: namoshek/rabbitmq-github-action@v1
-        with:
-          ports: '61613:61613'
-          plugins: rabbitmq_stomp
-
       - name: Run tests
         run: pytest
+
+      - name: Get logs of RabbitMQ
+        run: docker logs rabbitmq
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -29,13 +29,13 @@ jobs:
       - name: Lint
         run: tox -e pre-commit,mypy
 
-  test-activemq:
+  test:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
     strategy:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest"] # can add windows-latest, macos-latest
-        python: ["3.9", "3.11"]
+        python: ["3.9", "3.10", "3.11"]
         install: [".[dev]"]
 
     services:
@@ -48,53 +48,15 @@ jobs:
     env:
       # https://github.com/pytest-dev/pytest/issues/2042
       PY_IGNORE_IMPORTMISMATCH: "1"
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          # Need this to get version number from last tag
-          fetch-depth: 0
-
-      - name: Install python packages
-        uses: ./.github/actions/install_requirements
-        with:
-          python_version: ${{ matrix.python }}
-          requirements_file: requirements-test-${{ matrix.os }}-${{ matrix.python }}.txt
-          install_options: ${{ matrix.install }}
-
-      - name: List dependency tree
-        run: pipdeptree
-
-      - name: Run tests
-        run: pytest
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
-        with:
-          name: ${{ matrix.python }}/${{ matrix.os }}-activemq
-          files: cov.xml
-
-  test-rabbitmq:
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
-    strategy:
-      fail-fast: false
-      matrix:
-        os: ["ubuntu-latest"] # can add windows-latest, macos-latest
-        python: ["3.9", "3.10", "3.11"]
-        install: [".[dev]", "-e .[dev]"]
-
-    runs-on: ${{ matrix.os }}
-    env:
-      # https://github.com/pytest-dev/pytest/issues/2042
-      PY_IGNORE_IMPORTMISMATCH: "1"
+      BLUEAPI_TEST_STOMP_PORTS: "[61613,61614]"
+      
 
     steps:
       - name: Start RabbitMQ
         uses: namoshek/rabbitmq-github-action@v1
         with:
-          ports: '61613:61613'
-          plugins: rabbitmq_stomp
+          ports: '61614:61613'
+          plugins: rabbitmq_stomp  
 
       - name: Checkout
         uses: actions/checkout@v3
@@ -118,7 +80,7 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:
-          name: ${{ matrix.python }}/${{ matrix.os }}-rabbitmq
+          name: ${{ matrix.python }}/${{ matrix.os }}
           files: cov.xml
 
   dist:
@@ -158,7 +120,7 @@ jobs:
         run: python -m $(ls src | head -1) --version
 
   container:
-    needs: [lint, dist, test-activemq, test-rabbitmq]
+    needs: [lint, dist, test]
     runs-on: ubuntu-latest
 
     permissions:
@@ -219,7 +181,7 @@ jobs:
 
   release:
     # upload to PyPI and make a release on every tag
-    needs: [lint, dist, test-activemq, test-rabbitmq]
+    needs: [lint, dist, test]
     if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags') }}
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -36,7 +36,7 @@ jobs:
       matrix:
         os: ["ubuntu-latest"] # can add windows-latest, macos-latest
         python: ["3.9", "3.10", "3.11"]
-        install: [".[dev]"]
+        install: [".[dev]", "-e .[dev]"]
 
     services:
       activemq:

--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -35,8 +35,8 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest"] # can add windows-latest, macos-latest
-        python: ["3.9", "3.10", "3.11"]
-        install: [".[dev]", "-e .[dev]"]
+        python: ["3.9", "3.11"]
+        install: [".[dev]"]
 
     services:
       activemq:

--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -35,8 +35,8 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest"] # can add windows-latest, macos-latest
-        python: ["3.11"]  # ["3.9", "3.10", "3.11"]
-        install: [".[dev]"]  # [".[dev]", "-e .[dev]"]
+        python: ["3.9", "3.10", "3.11"]
+        install: [".[dev]", "-e .[dev]"]
 
     services:
       activemq:
@@ -81,8 +81,8 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest"] # can add windows-latest, macos-latest
-        python: ["3.11"]  # ["3.9", "3.10", "3.11"]
-        install: [".[dev]"]  # [".[dev]", "-e .[dev]"]
+        python: ["3.9", "3.10", "3.11"]
+        install: [".[dev]", "-e .[dev]"]
 
     runs-on: ${{ matrix.os }}
     env:
@@ -114,9 +114,6 @@ jobs:
 
       - name: Run tests
         run: pytest
-
-      - name: Get logs of RabbitMQ
-        run: docker logs rabbitmq
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3

--- a/docs/developer/how-to/run-tests.rst
+++ b/docs/developer/how-to/run-tests.rst
@@ -11,42 +11,54 @@ It will also report coverage to the commandline and to ``cov.xml``.
 .. _pytest: https://pytest.org/
 .. _look like tests: https://docs.pytest.org/explanation/goodpractices.html#test-discovery
 
-Configuring message busses
---------------------------
-
-The tests for communicating with a message bus over stomp support either ActiveMQ or RabbitMQ
-with the ```rabbitmq_stomp``` plugin installed. The tests assume that such a broker is available
-on ```localhost:61613```: if you require a different host or port, edit StompConfig in config.py.
-
-ActiveMQ:
-For testing and development purposes, the outdated and unmaintained ActiveMQ community image is sufficient
-if you do  not already have an ActiveMQ installation, but it is **not recommended** for deployment or long term use.
-
-Running the ActiveMQ container image with stomp port 61613 and management port 8161 forwarded to localhost:
-
-```docker run -p 61613:61613 -p 8161:8161 rmohr/activemq```
-
-RabbitMQ:
-As the RabbitMQ container image is actively maintained and packaged into a Helm chart, this is the recommended
-message bus for active deployments. For testing and deployment it does require that the ```rabbitmq_stomp```
-plugin is enabled, and that StompConfig in config.py has Authentication enabled.
-
-Running the RabbitMQ container image with stomp port 61613 and management port 15672 forwarded:
-
-```docker run -p 61613:61613 -p 15672:15672 --name rabbitmq rabbitmq/management```
-
-Enabling the rabbitmq_stomp plugin
-
-```docker exec rabbitmq rabbitmq-plugins enable rabbitmq_stomp```
-
 Skipping the message bus tests
 ------------------------------
 
 The tests for stomp require connection to a live broker and will fail
-if one is not present. This can be inconvenient if you wish to test changes 
+if one is not present. This can be inconvenient if you wish to test changes
 that are unrelated to the broker, you can avoid this with::
 
     $ tox -e pytest -- --skip-stomp
 
 The stomp tests are still run against a live broker in CI to ensure nothing
 slips through the cracks.
+
+Configuring message busses
+--------------------------
+
+The tests for communicating with a message bus over stomp support either ActiveMQ or RabbitMQ
+with the ```rabbitmq_stomp``` plugin installed. The tests assume that such a broker is available
+on ```localhost:61613```: if you require a different host or port, edit StompConfig in config.py
+or set the `BLUEAPI_TEST_STOMP_PORTS` environment variable: this variable is a list of values
+so the tests can be run against multiple brokers::
+
+    # Default behaviour
+    $ export BLUEAPI_TEST_STOMP_PORTS="[61613]"
+
+    # Broker is running on a different port
+    $ export BLUEAPI_TEST_STOMP_PORTS="[61614]"
+
+    # Multiple brokers are running on multiple ports, the tests will be run once per broker
+    $ export BLUEAPI_TEST_STOMP_PORTS="[61613, 61614]"
+
+ActiveMQ:
+For testing and development purposes, the outdated and unmaintained ActiveMQ community image is sufficient
+if you do  not already have an ActiveMQ installation, but it is **not recommended** for deployment or long term use.
+
+Running the ActiveMQ container image with stomp port 61613 and management port 8161 forwarded to localhost::
+
+    $ docker run -p 61613:61613 -p 8161:8161 rmohr/activemq
+
+RabbitMQ:
+As the RabbitMQ container image is actively maintained and packaged into a Helm chart, this is the recommended
+message bus for active deployments. For testing and deployment it does require that the ```rabbitmq_stomp```
+plugin is enabled, and that StompConfig in config.py has Authentication enabled.
+
+Running the RabbitMQ container image with stomp port 61613 and management port 15672 forwarded::
+
+    $ docker run -p 61613:61613 -p 15672:15672 --name rabbitmq rabbitmq/management
+
+Enabling the rabbitmq_stomp plugin::
+
+    $ docker exec rabbitmq rabbitmq-plugins enable rabbitmq_stomp
+

--- a/docs/developer/how-to/run-tests.rst
+++ b/docs/developer/how-to/run-tests.rst
@@ -11,11 +11,38 @@ It will also report coverage to the commandline and to ``cov.xml``.
 .. _pytest: https://pytest.org/
 .. _look like tests: https://docs.pytest.org/explanation/goodpractices.html#test-discovery
 
-
-Skip the message bus tests
+Configuring message busses
 --------------------------
 
-The tests for stomp require connection to a live ActiveMQ broker and will fail
+The tests for communicating with a message bus over stomp support either ActiveMQ or RabbitMQ
+with the ```rabbitmq_stomp``` plugin installed. The tests assume that such a broker is available
+on ```localhost:61613```: if you require a different host or port, edit StompConfig in config.py.
+
+ActiveMQ:
+For testing and development purposes, the outdated and unmaintained ActiveMQ community image is sufficient
+if you do  not already have an ActiveMQ installation, but it is **not recommended** for deployment or long term use.
+
+Running the ActiveMQ container image with stomp port 61613 and management port 8161 forwarded to localhost:
+
+```docker run -p 61613:61613 -p 8161:8161 rmohr/activemq```
+
+RabbitMQ:
+As the RabbitMQ container image is actively maintained and packaged into a Helm chart, this is the recommended
+message bus for active deployments. For testing and deployment it does require that the ```rabbitmq_stomp```
+plugin is enabled, and that StompConfig in config.py has Authentication enabled.
+
+Running the RabbitMQ container image with stomp port 61613 and management port 15672 forwarded:
+
+```docker run -p 61613:61613 -p 15672:15672 --name rabbitmq rabbitmq/management```
+
+Enabling the rabbitmq_stomp plugin
+
+```docker exec rabbitmq rabbitmq-plugins enable rabbitmq_stomp```
+
+Skipping the message bus tests
+------------------------------
+
+The tests for stomp require connection to a live broker and will fail
 if one is not present. This can be inconvenient if you wish to test changes 
 that are unrelated to the broker, you can avoid this with::
 

--- a/docs/developer/how-to/run-tests.rst
+++ b/docs/developer/how-to/run-tests.rst
@@ -11,8 +11,8 @@ It will also report coverage to the commandline and to ``cov.xml``.
 .. _pytest: https://pytest.org/
 .. _look like tests: https://docs.pytest.org/explanation/goodpractices.html#test-discovery
 
-Skipping the message bus tests
-------------------------------
+Skip the message bus tests
+--------------------------
 
 The tests for stomp require connection to a live broker and will fail
 if one is not present. This can be inconvenient if you wish to test changes
@@ -23,8 +23,8 @@ that are unrelated to the broker, you can avoid this with::
 The stomp tests are still run against a live broker in CI to ensure nothing
 slips through the cracks.
 
-Configuring message busses
---------------------------
+Configure message busses
+------------------------
 
 The tests for communicating with a message bus over stomp support either ActiveMQ or RabbitMQ
 with the ```rabbitmq_stomp``` plugin installed. The tests assume that such a broker is available

--- a/docs/developer/how-to/run-tests.rst
+++ b/docs/developer/how-to/run-tests.rst
@@ -11,6 +11,7 @@ It will also report coverage to the commandline and to ``cov.xml``.
 .. _pytest: https://pytest.org/
 .. _look like tests: https://docs.pytest.org/explanation/goodpractices.html#test-discovery
 
+
 Skip the message bus tests
 --------------------------
 
@@ -29,7 +30,7 @@ Configure message busses
 The tests for communicating with a message bus over stomp support either ActiveMQ or RabbitMQ
 with the ```rabbitmq_stomp``` plugin installed. The tests assume that such a broker is available
 on ```localhost:61613```: if you require a different host or port, edit StompConfig in config.py
-or set the `BLUEAPI_TEST_STOMP_PORTS` environment variable: this variable is a list of values
+or set the ```BLUEAPI_TEST_STOMP_PORTS``` environment variable: this variable is a list of values
 so the tests can be run against multiple brokers::
 
     # Default behaviour

--- a/helm/blueapi/values.yaml
+++ b/helm/blueapi/values.yaml
@@ -66,8 +66,8 @@ worker:
         module: blueapi.plans
   stomp:
     auth:
-      user: guest
-      password: guest # TODO: Enable existingPasswordSecret
-    host: activemq
+      username: guest
+      passcode: guest
+    host: rabbitmq
     port: 61613
 # Config for the worker goes here, will be mounted into a config file

--- a/helm/blueapi/values.yaml
+++ b/helm/blueapi/values.yaml
@@ -65,6 +65,9 @@ worker:
       - kind: planFunctions
         module: blueapi.plans
   stomp:
+    auth:
+      user: guest
+      password: guest # TODO: Enable existingPasswordSecret
     host: activemq
     port: 61613
 # Config for the worker goes here, will be mounted into a config file

--- a/src/blueapi/config.py
+++ b/src/blueapi/config.py
@@ -23,7 +23,7 @@ class Source(BaseModel):
 
 class BasicAuthentication(BaseModel):
     """
-    Log in details for stomp when the stomp server uses authentication
+    Log in details for when a server uses authentication
     """
 
     username: str = "guest"

--- a/src/blueapi/config.py
+++ b/src/blueapi/config.py
@@ -1,11 +1,10 @@
 from enum import Enum
 from pathlib import Path
-from typing import Any, Generic, Literal, Mapping, Type, TypeVar, Union
+from typing import Any, Generic, Literal, Mapping, Type, TypeVar, Union, Optional
 
 import yaml
-from pydantic import BaseModel, Field, ValidationError, parse_obj_as
-
 from blueapi.utils import BlueapiBaseModel, InvalidConfigError
+from pydantic import BaseModel, Field, ValidationError, parse_obj_as
 
 LogLevel = Literal["NOTSET", "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
 
@@ -21,6 +20,14 @@ class Source(BaseModel):
     module: Union[Path, str]
 
 
+class BasicAuthentication(BaseModel):
+    """
+    Log in details for stomp when the stomp server uses authentication
+    """
+    username: str = "guest"
+    passcode: Optional[str] = "guest"
+
+
 class StompConfig(BaseModel):
     """
     Config for connecting to stomp broker
@@ -28,6 +35,7 @@ class StompConfig(BaseModel):
 
     host: str = "localhost"
     port: int = 61613
+    auth: Optional[BasicAuthentication] = None
 
 
 class EnvironmentConfig(BlueapiBaseModel):

--- a/src/blueapi/config.py
+++ b/src/blueapi/config.py
@@ -27,7 +27,7 @@ class BasicAuthentication(BaseModel):
     """
 
     username: str = "guest"
-    passcode: Optional[str] = "guest"
+    passcode: str = "guest"
 
 
 class StompConfig(BaseModel):

--- a/src/blueapi/config.py
+++ b/src/blueapi/config.py
@@ -1,10 +1,11 @@
 from enum import Enum
 from pathlib import Path
-from typing import Any, Generic, Literal, Mapping, Type, TypeVar, Union, Optional
+from typing import Any, Generic, Literal, Mapping, Optional, Type, TypeVar, Union
 
 import yaml
-from blueapi.utils import BlueapiBaseModel, InvalidConfigError
 from pydantic import BaseModel, Field, ValidationError, parse_obj_as
+
+from blueapi.utils import BlueapiBaseModel, InvalidConfigError
 
 LogLevel = Literal["NOTSET", "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
 
@@ -24,6 +25,7 @@ class BasicAuthentication(BaseModel):
     """
     Log in details for stomp when the stomp server uses authentication
     """
+
     username: str = "guest"
     passcode: Optional[str] = "guest"
 

--- a/src/blueapi/messaging/base.py
+++ b/src/blueapi/messaging/base.py
@@ -97,7 +97,9 @@ class MessagingTemplate(ABC):
             obj (Any): Message to send, must be serializable
             reply_type (Type, optional): Expected type of reply, used
                                          in deserialization. Defaults to str.
-
+            correlation_id (Optional[str]): An id which correlates this request with
+                                                requests it spawns or the request which
+                                                spawned it etc.
         Returns:
             Future: Future representing the reply
         """
@@ -114,9 +116,9 @@ class MessagingTemplate(ABC):
     @abstractmethod
     def send(
         self,
-        __destination: str,
-        __obj: Any,
-        __on_reply: Optional[MessageListener] = None,
+        destination: str,
+        obj: Any,
+        on_reply: Optional[MessageListener] = None,
         correlation_id: Optional[str] = None,
     ) -> None:
         """
@@ -125,8 +127,11 @@ class MessagingTemplate(ABC):
         Args:
             destination (str): Destination to send the message
             obj (Any): Message to send, must be serializable
-            __on_reply (Optional[MessageListener], optional): Callback function for
+            on_reply (Optional[MessageListener], optional): Callback function for
                                                               a reply. Defaults to None.
+            correlation_id (Optional[str]): An id which correlates this request with
+                                                requests it spawns or the request which
+                                                spawned it etc.
         """
 
     def listener(self, destination: str):
@@ -150,8 +155,8 @@ class MessagingTemplate(ABC):
     @abstractmethod
     def subscribe(
         self,
-        __destination: str,
-        __callback: MessageListener,
+        destination: str,
+        callback: MessageListener,
     ) -> None:
         """
         Subscribe to messages from a particular destination. Requires
@@ -161,11 +166,11 @@ class MessagingTemplate(ABC):
             ...
 
         The type annotation of the message will be inspected and used in
-        deserialilization.
+        deserialization.
 
         Args:
-            __destination (str): Destination to subscribe to
-            __callback (MessageListener): What to do with each message
+            destination (str): Destination to subscribe to
+            callback (MessageListener): What to do with each message
         """
 
     @abstractmethod

--- a/src/blueapi/messaging/base.py
+++ b/src/blueapi/messaging/base.py
@@ -117,7 +117,7 @@ class MessagingTemplate(ABC):
         __destination: str,
         __obj: Any,
         __on_reply: Optional[MessageListener] = None,
-        __correlation_id: Optional[str] = None,
+        correlation_id: Optional[str] = None,
     ) -> None:
         """
         Send a message to a destination

--- a/src/blueapi/messaging/stomptemplate.py
+++ b/src/blueapi/messaging/stomptemplate.py
@@ -102,7 +102,11 @@ class StompMessagingTemplate(MessagingTemplate):
     @classmethod
     def autoconfigured(cls, config: StompConfig) -> MessagingTemplate:
         return cls(
-            stomp.Connection([(config.host, config.port)], auto_content_length=False)
+            stomp.Connection(
+                [(config.host, config.port)],
+                auto_content_length=False,
+            ),
+            authentication=config.auth,
         )
 
     @property

--- a/src/blueapi/messaging/stomptemplate.py
+++ b/src/blueapi/messaging/stomptemplate.py
@@ -153,7 +153,7 @@ class StompMessagingTemplate(MessagingTemplate):
             )
             callback(context, value)
 
-        sub_id = str(next(self._sub_num))
+        sub_id = destination if destination.startswith("/temp-queue/") else str(next(self._sub_num))
         self._subscriptions[sub_id] = Subscription(destination, wrapper)
         # If we're connected, subscribe immediately, otherwise the subscription is
         # deferred until connection.
@@ -175,6 +175,8 @@ class StompMessagingTemplate(MessagingTemplate):
         # on template before it connects, then just run the subscribes after connection.
         if self._conn.is_connected():
             for sub_id in sub_ids or self._subscriptions.keys():
+                if sub_id.startswith("/temp-queue/"):
+                    continue
                 sub = self._subscriptions[sub_id]
                 LOGGER.info(f"Subscribing to {sub.destination}")
                 self._conn.subscribe(destination=sub.destination, id=sub_id, ack="auto")

--- a/src/blueapi/messaging/stomptemplate.py
+++ b/src/blueapi/messaging/stomptemplate.py
@@ -82,10 +82,10 @@ class StompMessagingTemplate(MessagingTemplate):
     _destination_provider: DestinationProvider = StompDestinationProvider()
 
     def __init__(
-            self,
-            conn: stomp.Connection,
-            reconnect_policy: Optional[StompReconnectPolicy] = None,
-            authentication: Optional[BasicAuthentication] = None
+        self,
+        conn: stomp.Connection,
+        reconnect_policy: Optional[StompReconnectPolicy] = None,
+        authentication: Optional[BasicAuthentication] = None,
     ) -> None:
         self._conn = conn
         self._reconnect_policy = reconnect_policy or StompReconnectPolicy()

--- a/src/blueapi/messaging/stomptemplate.py
+++ b/src/blueapi/messaging/stomptemplate.py
@@ -190,8 +190,6 @@ class StompMessagingTemplate(MessagingTemplate):
         # on template before it connects, then just run the subscribes after connection.
         if self._conn.is_connected():
             for sub_id in sub_ids or self._subscriptions.keys():
-                if sub_id.startswith("/temp-queue/"):
-                    continue
                 sub = self._subscriptions[sub_id]
                 LOGGER.info(f"Subscribing to {sub.destination}")
                 self._conn.subscribe(destination=sub.destination, id=sub_id, ack="auto")

--- a/src/blueapi/messaging/stomptemplate.py
+++ b/src/blueapi/messaging/stomptemplate.py
@@ -153,7 +153,11 @@ class StompMessagingTemplate(MessagingTemplate):
             )
             callback(context, value)
 
-        sub_id = destination if destination.startswith("/temp-queue/") else str(next(self._sub_num))
+        sub_id = (
+            destination
+            if destination.startswith("/temp-queue/")
+            else str(next(self._sub_num))
+        )
         self._subscriptions[sub_id] = Subscription(destination, wrapper)
         # If we're connected, subscribe immediately, otherwise the subscription is
         # deferred until connection.
@@ -164,7 +168,7 @@ class StompMessagingTemplate(MessagingTemplate):
         self._conn.connect(
             username=self._authentication.username,
             passcode=self._authentication.passcode,
-            wait=True
+            wait=True,
         )
         self._listener.on_disconnected = self._on_disconnected
         self._ensure_subscribed()

--- a/tests/messaging/test_stomptemplate.py
+++ b/tests/messaging/test_stomptemplate.py
@@ -91,7 +91,7 @@ def test_listener(template: MessagingTemplate, test_queue: str) -> None:
         reply_queue = ctx.reply_destination
         if reply_queue is None:
             raise RuntimeError("reply queue is None")
-        template.send(reply_queue, "ack")
+        template.send(reply_queue, "ack", correlation_id=ctx.correlation_id)
 
     reply = template.send_and_receive(test_queue, "test", str).result(timeout=_TIMEOUT)
     assert reply == "ack"
@@ -114,7 +114,7 @@ def test_deserialization(
         reply_queue = ctx.reply_destination
         if reply_queue is None:
             raise RuntimeError("reply queue is None")
-        template.send(reply_queue, message)
+        template.send(reply_queue, message, correlation_id=ctx.correlation_id)
 
     template.subscribe(test_queue, server)
     reply = template.send_and_receive(test_queue, message, message_type).result(
@@ -155,7 +155,7 @@ def test_correlation_id(
 
     def server(ctx: MessageContext, msg: str) -> None:
         q.put(ctx)
-        template.send(test_queue_2, msg, None, ctx.correlation_id)
+        template.send(test_queue_2, msg, correlation_id=ctx.correlation_id)
 
     def client(ctx: MessageContext, msg: str) -> None:
         q.put(ctx)
@@ -175,6 +175,6 @@ def acknowledge(template: MessagingTemplate, destination: str) -> None:
         reply_queue = ctx.reply_destination
         if reply_queue is None:
             raise RuntimeError("reply queue is None")
-        template.send(reply_queue, "ack")
+        template.send(reply_queue, "ack", correlation_id=ctx.correlation_id)
 
     template.subscribe(destination, server)


### PR DESCRIPTION
- Add basic authentication to Stomp connection and Helm chart
- Handle RabbitMQ-style temporary queue behaviour
- Enable CI build against RabbitMQ container
- Add documentation for running against either message bus