### PR TITLE
Add headers to assist deserialising JMS messages in RMQ

### DIFF
--- a/src/blueapi/messaging/stomptemplate.py
+++ b/src/blueapi/messaging/stomptemplate.py
@@ -133,7 +133,7 @@ class StompMessagingTemplate(MessagingTemplate):
     ) -> None:
         LOGGER.info(f"SENDING {message} to {destination}")
 
-        headers: Dict[str, Any] = {}
+        headers: Dict[str, Any] = {"JMSType": "TextMessage"}
         if on_reply is not None:
             reply_queue_name = self.destinations.temporary_queue(str(uuid.uuid1()))
             headers = {**headers, "reply-to": reply_queue_name}


### PR DESCRIPTION
- Add RJMS only header to make deserialising as TextMessage override default deserialising as Bytes: easier to debug and handle.