### PR TITLE
Pin Pydantic to <2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "ophyd",
     "nslsii",
     "pyepics",
-    "pydantic",
+    "pydantic<2.0",
     "stomp.py",
     "scanspec",
     "PyYAML",


### PR DESCRIPTION
- Closes #270
- Dodal and our pinned version of typing_extensions both conflict with Pydantic2