### PR TITLE
Add defaults such that the Dockerfile can be built locally with no arguments

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -5,7 +5,7 @@
 #
 FROM python:3.11 as build
 
-ARG PIP_OPTIONS
+ARG PIP_OPTIONS=.
 
 # Add any system dependencies for the developer/build environment here e.g.
 # RUN apt-get update && apt-get upgrade -y && \


### PR DESCRIPTION
The dockerfile could only built with arguments, either a directory or a wheel to install from. This PR makes the default `.` so that it can be built without any arguments locally. The CI should be unaffected.