### PR TITLE
Make new fields of PlanModel optional to prevent incompatibility

### DIFF
--- a/docs/user/reference/openapi.yaml
+++ b/docs/user/reference/openapi.yaml
@@ -60,7 +60,6 @@ components:
           type: object
       required:
       - name
-      - schema
       title: PlanModel
       type: object
     PlanResponse:

--- a/src/blueapi/service/model.py
+++ b/src/blueapi/service/model.py
@@ -54,9 +54,13 @@ class PlanModel(BlueapiBaseModel):
     """
 
     name: str = Field(description="Name of the plan")
-    description: Optional[str] = Field(description="Docstring of the plan")
-    parameter_schema: dict[str, Any] = Field(
-        description="Schema of the plan's parameters", alias="schema"
+    description: Optional[str] = Field(
+        description="Docstring of the plan", default=None
+    )
+    parameter_schema: Optional[dict[str, Any]] = Field(
+        description="Schema of the plan's parameters",
+        alias="schema",
+        default_factory=dict,
     )
 
     @classmethod


### PR DESCRIPTION
- Client unable to deserialise PlanModel without parameter_schema when querying server older than change
- Makes parameter_schema optional to prevent making API incompatible between versions