### PR TITLE
Add support for scratch area to automatically add packages when running on Kubernetes

### DIFF
--- a/docs/user/how-to/add-plans-and-devices.rst
+++ b/docs/user/how-to/add-plans-and-devices.rst
@@ -97,6 +97,22 @@ You would add the following into your configuration file:
 You can have as many sources for plans and devices as are needed.
 
 
+Scratch Area on Kubernetes
+--------------------------
+
+Sometimes in-the-loop development of plans and devices may be required. If running blueapi out of a virtual environment local packages can be installed with ``pip install -e path/to/package``, but there is also a way to support editable packages on Kubernetes with a shared filesystem.
+
+Blueapi can be configured to install editable Python packages from a chosen directory, the helm chart can mount this directory from the
+host machine, include the following in your ``values.yaml``:
+
+.. code:: yaml
+
+  scratch:
+    hostPath: path/to/scratch/area  # e.g. /dls_sw/<my_beamline>/software/blueapi/scratch
+
+You can then clone projects into the scratch directory and blueapi will automatically incorporate them on startup. You must still include configuration to load the plans and devices from specific modules within those packages, see above. 
+
+
 .. _dodal: https://github.com/DiamondLightSource/dodal
 .. _`python skeleton`: https://diamondlightsource.github.io/python3-pip-skeleton/main/index.html
 .. _`New Skeleton Project Tutorial`: https://diamondlightsource.github.io/python3-pip-skeleton-cli/main/user/tutorials/new.html

--- a/helm/blueapi/templates/deployment.yaml
+++ b/helm/blueapi/templates/deployment.yaml
@@ -35,6 +35,12 @@ spec:
           - secret:
               name: {{ . }}
           {{- end }}
+      {{- if .Values.scratch.hostPath }}
+      - name: scratch-host
+        hostPath:
+          path: {{ .Values.scratch.hostPath }}
+          type: Directory
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -47,6 +53,11 @@ spec:
             - name: worker-config
               mountPath: "/config"
               readOnly: true
+            {{- if .Values.scratch.hostPath }}
+            - name: scratch-host
+              mountPath: {{ .Values.worker.env.scratch.path }}
+              mountPropagation: HostToContainer
+            {{- end }}
           command: ["blueapi"]
           args:
             - "-c"

--- a/helm/blueapi/values.yaml
+++ b/helm/blueapi/values.yaml
@@ -70,7 +70,7 @@ affinity: {}
 
 scratch:
   {}
-  # hostPath: /dls_sw/p38/software/
+  # hostPath: /usr/local/blueapi-software-scratch
 
 worker:
   api:

--- a/helm/blueapi/values.yaml
+++ b/helm/blueapi/values.yaml
@@ -68,6 +68,10 @@ affinity: {}
 
 #existingSecret: see templates/secret.yaml
 
+scratch:
+  {}
+  # hostPath: /dls_sw/p38/software/
+
 worker:
   api:
     host: 0.0.0.0 # Allow non-loopback traffic
@@ -78,6 +82,9 @@ worker:
         module: blueapi.startup.example
       - kind: planFunctions
         module: blueapi.plans
+    scratch:
+      path: /blueapi-plugins/scratch
+      auto_make_directory: true
   stomp:
     auth:
       username: guest

--- a/src/blueapi/config.py
+++ b/src/blueapi/config.py
@@ -1,17 +1,6 @@
 from enum import Enum
 from pathlib import Path
-from typing import (
-    Any,
-    Dict,
-    Generic,
-    List,
-    Literal,
-    Mapping,
-    Optional,
-    Type,
-    TypeVar,
-    Union,
-)
+from typing import Any, Dict, Generic, Literal, Mapping, Optional, Type, TypeVar, Union
 
 import yaml
 from pydantic import BaseModel, Field, ValidationError, parse_obj_as

--- a/src/blueapi/config.py
+++ b/src/blueapi/config.py
@@ -1,6 +1,17 @@
 from enum import Enum
 from pathlib import Path
-from typing import Any, Dict, Generic, Literal, Mapping, Optional, Type, TypeVar, Union
+from typing import (
+    Any,
+    Dict,
+    Generic,
+    List,
+    Literal,
+    Mapping,
+    Optional,
+    Type,
+    TypeVar,
+    Union,
+)
 
 import yaml
 from pydantic import BaseModel, Field, ValidationError, parse_obj_as
@@ -40,6 +51,14 @@ class StompConfig(BaseModel):
     auth: Optional[BasicAuthentication] = None
 
 
+class ScratchConfig(BlueapiBaseModel):
+    """
+    Config for the scratch space where editable Python packages can be installed
+    """
+
+    path: Path = Field(default=Path("/tmp/blueapi/scratch"))
+
+
 class EnvironmentConfig(BlueapiBaseModel):
     """
     Config for the RunEngine environment
@@ -53,6 +72,7 @@ class EnvironmentConfig(BlueapiBaseModel):
         Source(kind=SourceKind.PLAN_FUNCTIONS, module="dls_bluesky_core.plans"),
         Source(kind=SourceKind.PLAN_FUNCTIONS, module="dls_bluesky_core.stubs"),
     ]
+    scratch: Optional[ScratchConfig] = Field(default_factory=ScratchConfig)
 
     def __eq__(self, other: object) -> bool:
         if isinstance(other, EnvironmentConfig):

--- a/src/blueapi/config.py
+++ b/src/blueapi/config.py
@@ -57,6 +57,7 @@ class ScratchConfig(BlueapiBaseModel):
     """
 
     path: Path = Field(default=Path("/tmp/blueapi/scratch"))
+    auto_make_directory: bool = Field(default=False)
 
 
 class EnvironmentConfig(BlueapiBaseModel):

--- a/src/blueapi/config.py
+++ b/src/blueapi/config.py
@@ -62,7 +62,7 @@ class EnvironmentConfig(BlueapiBaseModel):
         Source(kind=SourceKind.PLAN_FUNCTIONS, module="dls_bluesky_core.plans"),
         Source(kind=SourceKind.PLAN_FUNCTIONS, module="dls_bluesky_core.stubs"),
     ]
-    scratch: Optional[ScratchConfig] = Field(default_factory=ScratchConfig)
+    scratch: Optional[ScratchConfig] = Field(default=None)
 
     def __eq__(self, other: object) -> bool:
         if isinstance(other, EnvironmentConfig):

--- a/src/blueapi/service/main.py
+++ b/src/blueapi/service/main.py
@@ -7,6 +7,7 @@ from starlette.responses import JSONResponse
 from super_state_machine.errors import TransitionError
 
 from blueapi.config import ApplicationConfig
+from blueapi.service.scratch import ScratchManager
 from blueapi.worker import RunPlan, TrackableTask, WorkerState
 
 from .handler import Handler, get_handler, setup_handler, teardown_handler
@@ -234,6 +235,10 @@ def set_state(
 
 def start(config: ApplicationConfig):
     import uvicorn
+
+    if config.env.scratch is not None:
+        scratch = ScratchManager.from_config(config.env.scratch)
+        scratch.sync_packages()
 
     app.state.config = config
     uvicorn.run(app, host=config.api.host, port=config.api.port)

--- a/src/blueapi/service/model.py
+++ b/src/blueapi/service/model.py
@@ -1,4 +1,5 @@
-from typing import Any, Iterable, List, Optional
+from pathlib import Path
+from typing import Any, Iterable, List, Optional, Set, Union
 
 from bluesky.protocols import HasName
 from pydantic import Field

--- a/src/blueapi/service/model.py
+++ b/src/blueapi/service/model.py
@@ -1,5 +1,4 @@
-from pathlib import Path
-from typing import Any, Iterable, List, Optional, Set, Union
+from typing import Any, Iterable, List, Optional
 
 from bluesky.protocols import HasName
 from pydantic import Field

--- a/src/blueapi/service/scratch.py
+++ b/src/blueapi/service/scratch.py
@@ -78,7 +78,10 @@ class ScratchManager:
         directories = self._get_directories_in_scratch()
         logging.info(f"Syncing scratch packages, installing from {directories}")
         for directory in directories:
-            self._pip.install_editable(directory, [])
+            try:
+                self._pip.install_editable(directory, [])
+            except subprocess.CalledProcessError as ex:
+                logging.error(f"Unable to install {directory}", ex)
         logging.info("Scratch packages installed")
 
     def _get_directories_in_scratch(self) -> Set[Path]:

--- a/src/blueapi/service/scratch.py
+++ b/src/blueapi/service/scratch.py
@@ -1,0 +1,101 @@
+import logging
+import os
+import subprocess
+import sys
+import time
+from abc import ABC, abstractmethod
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import Callable, Dict, List, Optional, Set
+
+import pkg_resources
+from pydantic import Field
+
+from blueapi.config import ScratchConfig
+from blueapi.utils import BlueapiBaseModel
+
+
+class PythonPackage(BlueapiBaseModel):
+    name: str
+    version: str
+    extras: List[str] = Field(default_factory=list)
+
+
+class PackageInstallation(BlueapiBaseModel):
+    package: PythonPackage
+    location: Path
+
+
+class PipShim:
+    """
+    Very simple class that wraps pip commands. Can be removed if pip
+    ever provides a programmatic API.
+    https://github.com/pypa/pip/issues/5675
+    """
+
+    def install_editable(
+        self,
+        path: Path,
+        extras: List[str],
+    ) -> None:
+        logging.debug(f"Installing {path}{extras}")
+        package_arg = str(path)
+        if len(extras) > 0:
+            extras_fmt = ",".join(extras)
+            package_source = f"{package_arg}[{extras_fmt}]"
+        else:
+            package_source = package_arg
+        subprocess.check_call(
+            [
+                sys.executable,
+                "-m",
+                "pip",
+                "install",
+                "-e",
+                package_source,
+            ]
+        )
+
+
+class ScratchManager:
+    """
+    Ensures editable packages are loaded from the scratch space, which is a "special" directory
+    """
+
+    _root_path: Path
+    _pip: PipShim
+
+    def __init__(
+        self,
+        root_path: Path,
+        pip: Optional[PipShim] = None,
+    ) -> None:
+        self._root_path = root_path
+        self._pip = pip or PipShim()
+
+    @classmethod
+    def from_config(cls, config: ScratchConfig) -> "ScratchManager":
+        return cls(config.path)
+
+    def sync_packages(self) -> None:
+        """
+        Editably install all packages in the scratch directory into blueapi's Python environment
+        """
+
+        self._check_scratch_exists()
+        directories = self._get_directories_in_scratch()
+        logging.info(f"Syncing scratch packages, installing from {directories}")
+        for directory in directories:
+            self._pip.install_editable(directory, [])
+        logging.info("Scratch packages installed")
+
+    def _get_directories_in_scratch(self) -> Set[Path]:
+        self._check_scratch_exists()
+        all_files = [self._root_path / child for child in os.listdir(self._root_path)]
+        return set(filter(lambda file: file.is_dir(), all_files))
+
+    def _check_scratch_exists(self) -> None:
+        if not self._root_path.exists():
+            raise FileNotFoundError(
+                f"Scratch directory {self._root_path} does not exist"
+            )

--- a/tests/service/test_scratch.py
+++ b/tests/service/test_scratch.py
@@ -1,0 +1,133 @@
+import sys
+import tempfile
+from pathlib import Path
+from typing import Iterable, List
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from blueapi.service.scratch import PipShim, ScratchManager
+
+
+@pytest.fixture
+def pip() -> MagicMock:
+    return MagicMock()
+
+
+@pytest.fixture
+def scratch_directory() -> MagicMock:
+    return MagicMock()
+
+
+@pytest.fixture
+def manager(
+    scratch_directory: Path,
+    pip: PipShim,
+) -> ScratchManager:
+    return ScratchManager(scratch_directory, True, pip)
+
+
+@pytest.fixture
+def non_auto_manager(
+    scratch_directory: Path,
+    pip: PipShim,
+) -> ScratchManager:
+    return ScratchManager(scratch_directory, False, pip)
+
+
+def test_errors_when_no_scratch_directory_and_not_allowed_to_auto_make(
+    scratch_directory: MagicMock,
+    non_auto_manager: ScratchManager,
+) -> None:
+    scratch_directory.is_file.return_value = False
+    scratch_directory.exists.return_value = False
+    with pytest.raises(FileNotFoundError):
+        non_auto_manager.sync_packages()
+
+
+def test_errors_when_scratch_path_is_a_file_and_not_allowed_to_auto_make(
+    non_auto_manager: ScratchManager,
+) -> None:
+    with pytest.raises(FileExistsError):
+        non_auto_manager.sync_packages()
+
+
+def test_errors_when_scratch_path_is_a_file_and_allowed_to_auto_make(
+    manager: ScratchManager,
+) -> None:
+    with pytest.raises(FileExistsError):
+        manager.sync_packages()
+
+
+def test_auto_make_directory(
+    scratch_directory: MagicMock,
+    manager: ScratchManager,
+) -> None:
+    scratch_directory.is_file.return_value = False
+    scratch_directory.exists.return_value = False
+    with patch("blueapi.service.scratch.os.listdir"):
+        manager.sync_packages()
+    scratch_directory.mkdir.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "subdirectories",
+    [
+        [],
+        ["foo"],
+        ["foo", "bar"],
+    ],
+)
+def test_does_pip_install(
+    scratch_directory: MagicMock,
+    pip: MagicMock,
+    manager: ScratchManager,
+    subdirectories: List[str],
+) -> None:
+    scratch_directory.is_file.return_value = False
+    with patch("blueapi.service.scratch.os.listdir") as listdir:
+        listdir.return_value = subdirectories
+        manager.sync_packages()
+
+    if len(subdirectories) > 0:
+        for directory in subdirectories:
+            inp = scratch_directory / directory
+            pip.install_editable.assert_called_once_with(inp, [])
+    else:
+        pip.install_editable.assert_not_called()
+
+
+def test_pip_shim_no_extras() -> None:
+    pip = PipShim()
+
+    with patch("blueapi.service.scratch.subprocess.check_call") as check_call:
+        pip.install_editable(Path("/foo/bar"), [])
+        check_call.assert_called_once_with(
+            [
+                sys.executable,
+                "-m",
+                "pip",
+                "install",
+                "--no-deps",
+                "-e",
+                "/foo/bar",
+            ]
+        )
+
+
+def test_pip_shim_with_extras() -> None:
+    pip = PipShim()
+
+    with patch("blueapi.service.scratch.subprocess.check_call") as check_call:
+        pip.install_editable(Path("/foo/bar"), ["dev", "shim"])
+        check_call.assert_called_once_with(
+            [
+                sys.executable,
+                "-m",
+                "pip",
+                "install",
+                "--no-deps",
+                "-e",
+                "/foo/bar[dev,shim]",
+            ]
+        )

--- a/tests/service/test_scratch.py
+++ b/tests/service/test_scratch.py
@@ -1,3 +1,4 @@
+import subprocess
 import sys
 import tempfile
 from pathlib import Path
@@ -95,6 +96,22 @@ def test_does_pip_install(
             pip.install_editable.assert_called_once_with(inp, [])
     else:
         pip.install_editable.assert_not_called()
+
+
+def test_handles_install_error(
+    scratch_directory: MagicMock,
+    pip: MagicMock,
+    manager: ScratchManager,
+) -> None:
+    scratch_directory.is_file.return_value = False
+    pip.install_editable.side_effect = [
+        None,
+        subprocess.CalledProcessError(1, ["foo", "bar"]),
+        None,
+    ]
+    with patch("blueapi.service.scratch.os.listdir") as listdir:
+        listdir.return_value = ["foo", "bar", "baz"]
+        manager.sync_packages()
 
 
 def test_pip_shim_no_extras() -> None:

--- a/tests/service/test_scratch.py
+++ b/tests/service/test_scratch.py
@@ -1,8 +1,7 @@
 import subprocess
 import sys
-import tempfile
 from pathlib import Path
-from typing import Iterable, List
+from typing import List
 from unittest.mock import MagicMock, patch
 
 import pytest


### PR DESCRIPTION
Recent discussion has emphasized the need for an area to checkout Python packages and do dev work against a live instance of blueapi running on Kubernetes. This has previously been done by pushing alpha tags of various packages and continually rebuilding and redeploying the blueapi container, which has become a lengthy and unweildy process.

This PR introduces the "scratch area", a shared directory that can be mounted from the container running on kubernetes, and can install any (pip installable) Python libraries that are cloned into it. In the cases where a dev version of an existing dependency is required (e.g. Dodal), the cloned version will overwrite the existing version installed in the container.
Removing a package and restarting the container works like a factory reset. See documentation addtions for more information.

Changes:
* Add confiugration for a scratch directory
* If configured, make blueapi pip install all packages in it on startup
* If configured, automatically create the scratch directory on startup
* Mount scratch in the helm chart if configured
* Tests and docs for new functionality