### PR TITLE
Reload modules after scratch install

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -24,7 +24,7 @@ WORKDIR /context
 # install python package into /venv
 RUN pip install ${PIP_OPTIONS}
 
-FROM python:3.11-slim as runtime
+FROM python:3.11 as runtime
 
 # Add apt-get system dependecies for runtime here if needed
 

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -8,9 +8,6 @@ env:
       module: dls_bluesky_core.plans
     - kind: planFunctions
       module: dls_bluesky_core.stubs
-  scratch:
-    path: /blueapi-plugins/scratch
-    auto_make_directory: true
 stomp:
   host: localhost
   port: 61613

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -8,6 +8,9 @@ env:
       module: dls_bluesky_core.plans
     - kind: planFunctions
       module: dls_bluesky_core.stubs
+  scratch:
+    path: /blueapi-plugins/scratch
+    auto_make_directory: true
 stomp:
   host: localhost
   port: 61613

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -170,6 +170,7 @@ html_theme_options = dict(
             url=f"https://github.com/{github_user}/{github_repo}/releases",
         )
     ],
+    navigation_with_keys=True,
 )
 
 # A dictionary of values to pass into the template engine’s context for all pages


### PR DESCRIPTION
Changes:
- For any modules in scratch that replace exisitnng dependnecies, `importlib.reload()` is called
- Dockerfile now includes a larger Python container with tools needed to pip install