### PR TITLE
Fix dependency on dodal

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "ophyd",
     "nslsii",
     "pyepics",
+    "aioca",
     "pydantic<2.0",
     "stomp.py",
     "aiohttp",
@@ -25,8 +26,8 @@ dependencies = [
     "fastapi[all]<0.100",
     "uvicorn",
     "requests",
-    "dls-bluesky-core @ git+https://github.com/DiamondLightSource/dls-bluesky-core.git",  #requires ophyd-async
-    "dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git@directory_provider", # requires aioca...
+    "dls-bluesky-core @ git+https://github.com/DiamondLightSource/dls-bluesky-core.git", #requires ophyd-async
+    "dls-dodal",
     "typing_extensions<4.6",
 ]
 dynamic = ["version"]


### PR DESCRIPTION
A dependency on a specific branch of dodal was mistakenly merged in #315. This PR reverts that dependency to use the release on PyPi.