### PR TITLE
Add option to helm chart to run on host network

### DIFF
--- a/helm/blueapi/templates/deployment.yaml
+++ b/helm/blueapi/templates/deployment.yaml
@@ -18,6 +18,7 @@ spec:
       labels:
         {{- include "blueapi.selectorLabels" . | nindent 8 }}
     spec:
+      hostNetwork: {{ .Values.hostNetwork }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/helm/blueapi/values.yaml
+++ b/helm/blueapi/values.yaml
@@ -68,6 +68,8 @@ affinity: {}
 
 #existingSecret: see templates/secret.yaml
 
+hostNetwork: false # May be needed for talking to arcane protocols such as EPICS
+
 scratch:
   hostPath: "" # example: /usr/local/blueapi-software-scratch
   containerPath: /blueapi-plugins/scratch


### PR DESCRIPTION
Changes:
- Add option to helm chart to run on host network, disabled by default