### PR TITLE
Make scratch area of startup script configurable for blueapi container

### DIFF
--- a/.devcontainer/container-startup.sh
+++ b/.devcontainer/container-startup.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
-SCRATCH_AREA="/blueapi-plugins/scratch"
+if [[ -z "${SCRATCH_AREA}" ]]; then
+  SCRATCH_AREA="/blueapi-plugins/scratch"
+fi
 
 mkdir -p ${SCRATCH_AREA}
 

--- a/helm/blueapi/templates/deployment.yaml
+++ b/helm/blueapi/templates/deployment.yaml
@@ -67,6 +67,9 @@ spec:
             - "/config/secret.yaml"
             {{- end }}
             - "serve"
+          env:
+            - name: SCRATCH_AREA
+              value: {{ .Values.scratch.containerPath }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
Currently, we have a linkam plan in i22-bluesky that makes an .xml file, and then sets a PV value to retrieveing this xml.

Currently the blueapi container on p38 is failing to make this .xml file because, although the correct location from Diamond workstations is mounted into it, it's mounted in a different containerPath. This is a problem, because it adds extra complexity to the bit of code in i22-bluesky which needs to 1. create the xml file and 2. set the IOC to look at it. The complexity being, that we now need to keep track of two filepaths (one inside the container, one out).

Seeing as though we are currently reliant on the filesystem, it is not much of a crime to demand that for now, the container scratch area is configurable.