### PR TITLE
 Allow passing kwargs to make_all_devices for dodal modules (again)

### DIFF
--- a/src/blueapi/core/context.py
+++ b/src/blueapi/core/context.py
@@ -138,10 +138,10 @@ class BlueskyContext:
     def with_device_module(self, module: ModuleType) -> None:
         self.with_dodal_module(module)
 
-    def with_dodal_module(self, module: ModuleType) -> None:
+    def with_dodal_module(self, module: ModuleType, **kwargs) -> None:
         from dodal.utils import make_all_devices
 
-        for device in make_all_devices(module).values():
+        for device in make_all_devices(module, **kwargs).values():
             self.device(device)
 
     def plan(self, plan: PlanGenerator) -> PlanGenerator:

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import Dict, List, Type, Union
+from unittest.mock import patch
 
 import pytest
 from bluesky.protocols import Descriptor, Movable, Readable, Reading, SyncOrAsync
@@ -169,6 +170,24 @@ def test_add_devices_from_module(empty_context: BlueskyContext) -> None:
         "motor_bundle_a",
         "motor_bundle_b",
     } == empty_context.devices.keys()
+
+
+def test_extra_kwargs_in_with_dodal_module_passed_to_make_all_devices(
+    empty_context: BlueskyContext,
+) -> None:
+    """
+    Note that this functionality is currently used by hyperion.
+    """
+    import tests.core.fake_device_module as device_module
+
+    with patch("dodal.utils.make_all_devices") as mock_make_all_devices:
+        empty_context.with_dodal_module(
+            device_module, some_argument=1, another_argument="two"
+        )
+
+        mock_make_all_devices.assert_called_once_with(
+            device_module, some_argument=1, another_argument="two"
+        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Functionality added in https://github.com/DiamondLightSource/blueapi/pull/304 and [being used in hyperion](https://github.com/DiamondLightSource/hyperion/blob/92b23dac5efc1aa78910d2f0f4bd28725a9ec836/src/hyperion/utils/context.py#L81) got removed in https://github.com/DiamondLightSource/blueapi/pull/315/commits/076da45193d3f3460d0481d2bc1a814a6193bcc3 . It doesn't look like there was a clear reason for this removal of functionality so I think it should be reinstated.