### PR TITLE
Add SecurityContext and volumeMounts to listener pod

### DIFF
--- a/helm/blueapi/templates/deployment.yaml
+++ b/helm/blueapi/templates/deployment.yaml
@@ -74,8 +74,14 @@ spec:
         - name: {{ .Chart.Name }}-document-listener
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
           resources:
             {{- toYaml .Values.listener.resources | nindent 12 }}
+          volumeMounts:
+            - name: worker-config
+              mountPath: "/config"
+              readOnly: true
           args:
             - "-c"
             - "/config/config.yaml"


### PR DESCRIPTION
At the moment, the listener pod does not have security context or config mounting.