### PR TITLE
Remove listener pod

### DIFF
--- a/helm/blueapi/templates/deployment.yaml
+++ b/helm/blueapi/templates/deployment.yaml
@@ -70,21 +70,6 @@ spec:
           env:
             - name: SCRATCH_AREA
               value: {{ .Values.scratch.containerPath }}
-        {{ if .Values.listener.enabled -}}
-        - name: {{ .Chart.Name }}-document-listener
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
-          resources:
-            {{- toYaml .Values.listener.resources | nindent 12 }}
-          args:
-            - "-c"
-            - "/config/config.yaml"
-            {{- with .Values.existingSecret }}
-            - "-c"
-            - "/config/secret.yaml"
-            {{- end }}
-            - "listen"
-        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
Change helm deployment so we don't spin up a pod in the blueapi deployment that just listens to documents.
At the moment, a deployment using release 0.3.14 fails due to securityContext issues, which when fixed still seem to cause problems. This should be investigated in future.