### PR TITLE
Fix shutdown

### DIFF
--- a/src/blueapi/messaging/base.py
+++ b/src/blueapi/messaging/base.py
@@ -184,3 +184,12 @@ class MessagingTemplate(ABC):
         """
         Disconnect the app from transport
         """
+
+    @abstractmethod
+    def is_connected(self) -> bool:
+        """
+        Returns status of the connection between the app and the transport.
+
+        Returns:
+            status (bool): Returns True if connected, False otherwise
+        """

--- a/src/blueapi/messaging/stomptemplate.py
+++ b/src/blueapi/messaging/stomptemplate.py
@@ -235,4 +235,3 @@ class StompMessagingTemplate(MessagingTemplate):
 
     def is_connected(self) -> bool:
         return self._conn.is_connected()
-

--- a/src/blueapi/messaging/stomptemplate.py
+++ b/src/blueapi/messaging/stomptemplate.py
@@ -232,3 +232,7 @@ class StompMessagingTemplate(MessagingTemplate):
             sub.callback(frame)
         else:
             LOGGER.warn(f"No subscription active for id: {sub_id}")
+
+    def is_connected(self) -> bool:
+        return self._conn.is_connected()
+

--- a/src/blueapi/service/handler.py
+++ b/src/blueapi/service/handler.py
@@ -80,7 +80,8 @@ class Handler:
 
     def stop(self) -> None:
         self.worker.stop()
-        self.messaging_template.disconnect()
+        if self.messaging_template.is_connected():
+            self.messaging_template.disconnect()
 
 
 HANDLER: Optional[Handler] = None

--- a/tests/messaging/test_stomptemplate.py
+++ b/tests/messaging/test_stomptemplate.py
@@ -154,7 +154,7 @@ def test_reconnect(template: MessagingTemplate, test_queue: str) -> None:
     template.disconnect()
     connected = template.is_connected()
     assert connected is False
-    
+
     template.connect()
     connected = template.is_connected()
     assert connected is True

--- a/tests/messaging/test_stomptemplate.py
+++ b/tests/messaging/test_stomptemplate.py
@@ -152,7 +152,12 @@ def test_reconnect(template: MessagingTemplate, test_queue: str) -> None:
     reply = template.send_and_receive(test_queue, "test", str).result(timeout=_TIMEOUT)
     assert reply == "ack"
     template.disconnect()
+    connected = template.is_connected()
+    assert connected is False
+    
     template.connect()
+    connected = template.is_connected()
+    assert connected is True
     reply = template.send_and_receive(test_queue, "test", str).result(timeout=_TIMEOUT)
     assert reply == "ack"
 

--- a/tests/messaging/test_stomptemplate.py
+++ b/tests/messaging/test_stomptemplate.py
@@ -152,12 +152,9 @@ def test_reconnect(template: MessagingTemplate, test_queue: str) -> None:
     reply = template.send_and_receive(test_queue, "test", str).result(timeout=_TIMEOUT)
     assert reply == "ack"
     template.disconnect()
-    connected = template.is_connected()
-    assert connected is False
-
+    assert not template.is_connected()
     template.connect()
-    connected = template.is_connected()
-    assert connected is True
+    assert template.is_connected()
     reply = template.send_and_receive(test_queue, "test", str).result(timeout=_TIMEOUT)
     assert reply == "ack"
 


### PR DESCRIPTION
Relates to #220 . This change is to enable blueapi to be shutdown with crtl+c when the activemq drops and it can no longer connect to it.