### PR TITLE
Add try except to messaging connection

### DIFF
--- a/src/blueapi/messaging/stomptemplate.py
+++ b/src/blueapi/messaging/stomptemplate.py
@@ -180,12 +180,18 @@ class StompMessagingTemplate(MessagingTemplate):
         self._listener.on_disconnected = self._on_disconnected
 
         LOGGER.info("Connecting...")
-        self._conn.connect(
-            username=self._authentication.username,
-            passcode=self._authentication.passcode,
-            wait=True,
-        )
-        connected.wait()
+
+        try:
+            self._conn.connect(
+                username=self._authentication.username,
+                passcode=self._authentication.passcode,
+                wait=True,
+            )
+            connected.wait()
+        except ConnectFailedException as ex:
+            LOGGER.error("Failed to connect")
+            LOGGER.exception(ex)
+
         self._ensure_subscribed()
 
     def _ensure_subscribed(self, sub_ids: Optional[List[str]] = None) -> None:


### PR DESCRIPTION
Fixes #220 (after a fashion). 

This is just a try except around the connection attempt. It displays the failure to connect in the logs but does not fail fast. It allows the rest of the application setup to complete just without a connection to a message bus. You can then `crtl+c` to close it. 

I would have preferred to fail fast if we are demanding the presence of a message bus, however trying to address exceptions in the fastapi `lifespan` caused things to hang. The I was advised to just add this crude fix until the subprocess work is done then we can re-address the behaviour we want for each of these cases.