### PR TITLE
Remove parameter caching inside task class

### DIFF
--- a/src/blueapi/worker/reworker.py
+++ b/src/blueapi/worker/reworker.py
@@ -129,7 +129,7 @@ class RunEngineWorker(Worker[Task]):
             raise KeyError(f"No pending task with ID {task_id}")
 
     def submit_task(self, task: Task) -> str:
-        task.prepare_params(self._ctx)
+        task.prepare_params(self._ctx)  # Will raise if parameters are invalid
         task_id: str = str(uuid.uuid4())
         trackable_task = TrackableTask(task_id=task_id, task=task)
         self._pending_tasks[task_id] = trackable_task

--- a/src/blueapi/worker/task.py
+++ b/src/blueapi/worker/task.py
@@ -20,22 +20,17 @@ class Task(BlueapiBaseModel):
     )
     _prepared_params: Optional[BaseModel] = None
 
-    def prepare_params(self, ctx: BlueskyContext) -> None:
-        self._ensure_params(ctx)
+    def prepare_params(self, ctx: BlueskyContext) -> BaseModel:
+        return _lookup_params(ctx, self)
 
     def do_task(self, ctx: BlueskyContext) -> None:
         LOGGER.info(f"Asked to run plan {self.name} with {self.params}")
 
         func = ctx.plan_functions[self.name]
-        prepared_params = self._ensure_params(ctx)
+        prepared_params = self.prepare_params(ctx)
         plan_generator = func(**prepared_params.dict())
         wrapped_plan_generator = ctx.wrap(plan_generator)
         ctx.run_engine(wrapped_plan_generator)
-
-    def _ensure_params(self, ctx: BlueskyContext) -> BaseModel:
-        if self._prepared_params is None:
-            self._prepared_params = _lookup_params(ctx, self)
-        return self._prepared_params
 
 
 # Here for backward compatibility pending

--- a/src/blueapi/worker/task.py
+++ b/src/blueapi/worker/task.py
@@ -18,7 +18,6 @@ class Task(BlueapiBaseModel):
     params: Mapping[str, Any] = Field(
         description="Values for parameters to plan, if any", default_factory=dict
     )
-    _prepared_params: Optional[BaseModel] = None
 
     def prepare_params(self, ctx: BlueskyContext) -> BaseModel:
         return _lookup_params(ctx, self)

--- a/src/blueapi/worker/task.py
+++ b/src/blueapi/worker/task.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Mapping, Optional
+from typing import Any, Mapping
 
 from pydantic import BaseModel, Field
 

--- a/tests/service/test_rest_api.py
+++ b/tests/service/test_rest_api.py
@@ -207,6 +207,7 @@ def test_create_task(handler: Handler, client: TestClient) -> None:
     assert pending is not None
     assert pending.task == _TASK
 
+
 def test_put_plan_begins_task(handler: Handler, client: TestClient) -> None:
     handler.start()
     response = client.post("/tasks", json=_TASK.dict())


### PR DESCRIPTION
Closes #369

The validated and processed parameters from a plan request were being cached inside the `Task` class because they were needed in two separate threads. Unfortunately, with the introduction of the subprocess (#343), pickling was causing issues with the cached object (see #369 for more details).

This PR is the simplest solution: remove the cache and generate the parameters twice. It also adds regression tests for the bug case in #369 