### PR TITLE
Update pyproject.toml to new stomp name

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "pyepics",
     "aioca",
     "pydantic<2.0",
-    "stomp.py",
+    "stomp-py",
     "aiohttp",
     "PyYAML",
     "click<8.1.4",


### PR DESCRIPTION
Stomp has changed it's name to `stomp-py` rather than `stomp.py`. This fixes the change