### PR TITLE
Auto restart deployment on config change

### DIFF
--- a/helm/blueapi/templates/deployment.yaml
+++ b/helm/blueapi/templates/deployment.yaml
@@ -11,8 +11,11 @@ spec:
       {{- include "blueapi.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
+      {{- if .Values.restartOnConfigChange }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+      {{- end }}
+      {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:

--- a/helm/blueapi/values.yaml
+++ b/helm/blueapi/values.yaml
@@ -68,6 +68,8 @@ affinity: {}
 
 hostNetwork: false # May be needed for talking to arcane protocols such as EPICS
 
+restartOnConfigChange: true
+
 listener:
   enabled: true
   resources: {}


### PR DESCRIPTION
Add new restartOnConfigChange property.

This will cause the deployment to be restarted if the config is changed,
e.g. the set of plans or device modules are updated, when running
helm upgrade.

Use a variation of approach at:
https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments

Fixes 451.