### PR TITLE
Pin sphinx-autobuild to fix starlette clash

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "aiohttp",
     "PyYAML",
     "click<8.1.4",
-    "fastapi[all]<0.99",
+    "fastapi[all]<0.99", # Later versions use a newer openapi schema, which is incompatible with swagger see https://github.com/swagger-api/swagger-codegen/issues/10446
     "uvicorn",
     "requests",
     "dls-bluesky-core",  #requires ophyd-async
@@ -44,7 +44,7 @@ dev = [
     "pytest-cov",
     "pytest-asyncio",
     "ruff",
-    "sphinx-autobuild",
+    "sphinx-autobuild==2024.2.4", # Later versions have a clash with fastapi<0.99, remove pin when fastapi is a higher version
     "sphinx-copybutton",
     "sphinx-click",
     "sphinx-design",


### PR DESCRIPTION
Fixes #454

To test:
* Re install `blueapi` dependencies
* `pip list`
* Confirm the installed `starlette`version is `0.27.0`