### PR TITLE
Rename update_task and add some docstrings to REST endpoint methods

### DIFF
--- a/docs/reference/openapi.yaml
+++ b/docs/reference/openapi.yaml
@@ -269,6 +269,8 @@ paths:
       summary: Get Device By Name
   /environment:
     delete:
+      description: Delete the current environment, causing internal components to
+        be reloaded.
       operationId: delete_environment_environment_delete
       responses:
         '200':
@@ -279,6 +281,7 @@ paths:
           description: Successful Response
       summary: Delete Environment
     get:
+      description: Get the current state of the environment, i.e. initialization state.
       operationId: get_environment_environment_get
       responses:
         '200':
@@ -492,7 +495,11 @@ paths:
           description: Successful Response
       summary: Get Active Task
     put:
-      operationId: update_task_worker_task_put
+      description: 'Set a task to active status, the worker should begin it as soon
+        as possible.
+
+        This will return an error response if the worker is not idle.'
+      operationId: set_active_task_worker_task_put
       requestBody:
         content:
           application/json:
@@ -515,4 +522,4 @@ paths:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
           description: Validation Error
-      summary: Update Task
+      summary: Set Active Task

--- a/src/blueapi/service/main.py
+++ b/src/blueapi/service/main.py
@@ -88,6 +88,7 @@ async def on_key_error_404(_: Request, __: KeyError):
 def get_environment(
     handler: BlueskyHandler = Depends(get_handler),
 ) -> EnvironmentResponse:
+    """Get the current state of the environment, i.e. initialization state."""
     return handler.state
 
 
@@ -96,6 +97,8 @@ async def delete_environment(
     background_tasks: BackgroundTasks,
     handler: BlueskyHandler = Depends(get_handler),
 ) -> EnvironmentResponse:
+    """Delete the current environment, causing internal components to be reloaded."""
+
     def restart_handler(handler: BlueskyHandler):
         handler.stop()
         handler.start()
@@ -216,10 +219,12 @@ def get_tasks(
     response_model=WorkerTask,
     responses={status.HTTP_409_CONFLICT: {"worker": "already active"}},
 )
-def update_task(
+def set_active_task(
     task: WorkerTask,
     handler: BlueskyHandler = Depends(get_handler),
 ) -> WorkerTask:
+    """Set a task to active status, the worker should begin it as soon as possible.
+    This will return an error response if the worker is not idle."""
     active_task = handler.active_task
     if active_task is not None and not active_task.is_complete:
         raise HTTPException(


### PR DESCRIPTION
The method names and docstrings are used in the OppenAPI schema (and therefore Swagger UI).

"update_task" was a bit vague as calling this actually starts the specified task.