### PR TITLE
Set umask in container

### DIFF
--- a/container-startup.sh
+++ b/container-startup.sh
@@ -1,18 +1,19 @@
 #!/usr/bin/env bash
 
+# Set umask to DLS standard
+umask 0002
+
 if [[ -z "${SCRATCH_AREA}" ]]; then
   SCRATCH_AREA="/blueapi-plugins/scratch"
 fi
 
-mkdir -p ${SCRATCH_AREA}
-
-DIRS=`ls -1 ${SCRATCH_AREA}`
-
-echo "Loading Python packages from from ${DIRS}"
-
-for DIR in ${DIRS}
-do
-    python -m pip install --no-deps -e "${SCRATCH_AREA}/${DIR}"
-done
+if [[ -d "${SCRATCH_AREA}" ]]; then
+  echo "Loading Python packages from ${SCRATCH_AREA}"
+  for DIR in ${SCRATCH_AREA}/*/; do # All directories
+    python -m pip install --no-deps -e "${DIR}"
+  done
+else
+  echo "blueapi scratch area not present"
+fi
 
 blueapi $@


### PR DESCRIPTION
Performing an editable install on a shared filesystem scratch area causes cache/version files to be written in the source repository.

With the container's default umask of 0022 the files are not group writable which can lead to frustration when attempting to clean up the scratch area.

Use the DLS "standard" of 0002.

Additionally modify the looping to only pickup directories within the scratch area.

Fixes #478.