### PR TITLE
Configurable global plan wrapper

### DIFF
--- a/src/blueapi/config.py
+++ b/src/blueapi/config.py
@@ -73,6 +73,7 @@ class EnvironmentConfig(BlueapiBaseModel):
         Source(kind=SourceKind.PLAN_FUNCTIONS, module="dls_bluesky_core.stubs"),
     ]
     events: WorkerEventConfig = Field(default_factory=WorkerEventConfig)
+    global_plan_wrapper: str | None = None
 
 
 class LoggingConfig(BlueapiBaseModel):

--- a/src/blueapi/core/context.py
+++ b/src/blueapi/core/context.py
@@ -43,8 +43,13 @@ class BlueskyContext:
     plans: dict[str, Plan] = field(default_factory=dict)
     devices: dict[str, Device] = field(default_factory=dict)
     plan_functions: dict[str, PlanGenerator] = field(default_factory=dict)
+    global_plan_wrapper: PlanGenerator | None = None
 
     _reference_cache: dict[type, type] = field(default_factory=dict)
+
+    def with_global_plan_wrapper(self, wrapper_name: str) -> None:
+        wrapper = self.plan_functions[wrapper_name]
+        self.global_plan_wrapper = wrapper
 
     def find_device(self, addr: str | list[str]) -> Device | None:
         """
@@ -74,6 +79,9 @@ class BlueskyContext:
                 self.with_device_module(mod)
             elif source.kind is SourceKind.DODAL:
                 self.with_dodal_module(mod)
+
+        if config.global_plan_wrapper is not None:
+            self.with_global_plan_wrapper(config.global_plan_wrapper)
 
     def with_plan_module(self, module: ModuleType) -> None:
         """

--- a/src/blueapi/worker/task.py
+++ b/src/blueapi/worker/task.py
@@ -28,7 +28,10 @@ class Task(BlueapiBaseModel):
 
         func = ctx.plan_functions[self.name]
         prepared_params = self.prepare_params(ctx)
-        ctx.run_engine(func(**prepared_params.dict()))
+        plan = func(**prepared_params.dict())
+        if ctx.global_plan_wrapper is not None:
+            plan = ctx.global_plan_wrapper(plan)
+        ctx.run_engine(plan)
 
 
 def _lookup_params(ctx: BlueskyContext, task: Task) -> BaseModel:

--- a/tests/worker/test_task.py
+++ b/tests/worker/test_task.py
@@ -1,0 +1,48 @@
+from unittest.mock import Mock
+
+import pytest
+from bluesky.plan_stubs import checkpoint, close_run, open_run
+
+from blueapi.core import BlueskyContext, MsgGenerator
+from blueapi.worker import Task
+
+
+def plan() -> MsgGenerator:
+    return "foo"
+
+
+def plan_with_params(param: str) -> MsgGenerator:
+    return "foo" + param
+
+
+def wrapper(plan: MsgGenerator) -> MsgGenerator:
+    return plan + "baz"
+
+
+@pytest.fixture
+def context() -> BlueskyContext:
+    ctx = BlueskyContext()
+    ctx.plan(plan)
+    ctx.plan(plan_with_params)
+    ctx.plan(wrapper)
+    ctx.run_engine = Mock()
+    return ctx
+
+
+def test_task_with_no_global_wrapper(context: BlueskyContext):
+    task = Task(name="plan")
+    task.do_task(context)
+    context.run_engine.assert_called_once_with("foo")  # type: ignore
+
+
+def test_task_with_wrapper(context: BlueskyContext):
+    context.with_global_plan_wrapper("wrapper")
+    task = Task(name="plan")
+    task.do_task(context)
+    context.run_engine.assert_called_once_with("foobaz")  # type: ignore
+
+
+def test_task_with_params(context: BlueskyContext):
+    task = Task(name="plan_with_params", params={"param": "bar"})
+    task.do_task(context)
+    context.run_engine.assert_called_once_with("foobar")  # type: ignore

--- a/tests/worker/test_task.py
+++ b/tests/worker/test_task.py
@@ -1,7 +1,6 @@
 from unittest.mock import Mock
 
 import pytest
-from bluesky.plan_stubs import checkpoint, close_run, open_run
 
 from blueapi.core import BlueskyContext, MsgGenerator
 from blueapi.worker import Task


### PR DESCRIPTION
Restore the global plan wrapper setting and make it configurable. Eventually we want to replace it with a combination of:
- https://github.com/DiamondLightSource/dodal/issues/576
- https://github.com/bluesky/ophyd-async/issues/314
But we need a working solution in the interim