### PR TITLE
Support lazy devices

### DIFF
--- a/src/blueapi/core/context.py
+++ b/src/blueapi/core/context.py
@@ -31,20 +31,6 @@ LOGGER = logging.getLogger(__name__)
 DevicesDict = dict[str, Device]
 
 
-def bisect_devices_dict(input_dict: DevicesDict) -> tuple[DevicesDict, DevicesDict]:
-    lazy_dict = {}
-    non_lazy_dict = {}
-
-    for key, value in input_dict.items():
-        # Assuming 'lazy' is an attribute or a condition you can check
-        if hasattr(value, "lazy") and value.lazy:
-            lazy_dict[key] = value
-        else:
-            non_lazy_dict[key] = value
-
-    return (non_lazy_dict, lazy_dict)
-
-
 @dataclass
 class BlueskyContext:
     """
@@ -126,7 +112,7 @@ class BlueskyContext:
         devices, exceptions = make_all_devices(module, **kwargs)
 
         # for non-lazy devices, we instantiate them
-        early_devices, _ = bisect_devices_dict(devices)
+        early_devices = devices.items().filter(lambda x: not x.lazy)
 
         for device in early_devices.values():
             self.register_device(device)

--- a/src/blueapi/core/context.py
+++ b/src/blueapi/core/context.py
@@ -42,6 +42,7 @@ class BlueskyContext:
     )
     plans: dict[str, Plan] = field(default_factory=dict)
     devices: dict[str, Device] = field(default_factory=dict)
+    # todo add some format to keep the lazy vs non-lazy devices
     plan_functions: dict[str, PlanGenerator] = field(default_factory=dict)
 
     _reference_cache: dict[type, type] = field(default_factory=dict)
@@ -104,6 +105,11 @@ class BlueskyContext:
 
     def with_dodal_module(self, module: ModuleType, **kwargs) -> None:
         devices, exceptions = make_all_devices(module, **kwargs)
+        # todo modify here
+        # factories = get_device_factories(module)
+
+        # for non-lazy devices, we instantiate them
+        # for lazy devices we add to the context to do when the plan is run
 
         for device in devices.values():
             self.device(device)

--- a/src/blueapi/core/context.py
+++ b/src/blueapi/core/context.py
@@ -112,9 +112,10 @@ class BlueskyContext:
         devices, exceptions = make_all_devices(module, **kwargs)
 
         # for non-lazy devices, we instantiate them
-        early_devices = devices.items().filter(lambda x: not x.lazy)
+        # eager_devices = devices.items().filter(lambda x: not x.lazy)
+        eager_devices = {k: v for k, v in devices.items() if not v.lazy}
 
-        for device in early_devices.values():
+        for device in eager_devices.values():
             self.register_device(device)
 
         # If exceptions have occurred, we log them but we do not make blueapi

--- a/src/blueapi/worker/task.py
+++ b/src/blueapi/worker/task.py
@@ -2,6 +2,7 @@ import logging
 from collections.abc import Mapping
 from typing import Any
 
+from ophyd_async.plan_stubs import ensure_connected
 from pydantic import BaseModel, Field
 
 from blueapi.core import BlueskyContext
@@ -26,8 +27,8 @@ class Task(BlueapiBaseModel):
     def do_task(self, ctx: BlueskyContext) -> None:
         LOGGER.info(f"Asked to run plan {self.name} with {self.params}")
 
-        # todo here call ensure_connected on alpl the devices marked in the context as needing that
-        # ensure_connected(ctx.lazy_devices.values())
+        lazy_devices = ctx.get_lazy_devices()
+        ensure_connected(devices=lazy_devices.values())
         func = ctx.plan_functions[self.name]
         prepared_params = self.prepare_params(ctx)
         ctx.run_engine(func(**prepared_params.dict()))

--- a/src/blueapi/worker/task.py
+++ b/src/blueapi/worker/task.py
@@ -26,6 +26,8 @@ class Task(BlueapiBaseModel):
     def do_task(self, ctx: BlueskyContext) -> None:
         LOGGER.info(f"Asked to run plan {self.name} with {self.params}")
 
+        # todo here call ensure_connected on alpl the devices marked in the context as needing that
+        # ensure_connected(ctx.lazy_devices.values())
         func = ctx.plan_functions[self.name]
         prepared_params = self.prepare_params(ctx)
         ctx.run_engine(func(**prepared_params.dict()))

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -96,8 +96,8 @@ def empty_context() -> BlueskyContext:
 @pytest.fixture
 def devicey_context(sim_motor: SynAxis, sim_detector: SynGauss) -> BlueskyContext:
     ctx = BlueskyContext()
-    ctx.device(sim_motor)
-    ctx.device(sim_detector)
+    ctx.register_device(sim_motor)
+    ctx.register_device(sim_detector)
     return ctx
 
 
@@ -117,7 +117,7 @@ def some_configurable() -> SomeConfigurable:
 
 @pytest.mark.parametrize("plan", [has_no_params, has_one_param, has_some_params])
 def test_add_plan(empty_context: BlueskyContext, plan: PlanGenerator) -> None:
-    empty_context.plan(plan)
+    empty_context.register_plan(plan)
     assert plan.__name__ in empty_context.plans
 
 
@@ -127,7 +127,7 @@ def test_generated_schema(
     def demo_plan(foo: int, mov: Movable) -> MsgGenerator:  # type: ignore
         ...
 
-    empty_context.plan(demo_plan)
+    empty_context.register_plan(demo_plan)
     schema = empty_context.plans["demo_plan"].model.schema()
     assert schema["properties"] == {
         "foo": {"title": "Foo", "type": "integer"},
@@ -140,7 +140,7 @@ def test_generated_schema(
 )
 def test_add_invalid_plan(empty_context: BlueskyContext, plan: PlanGenerator) -> None:
     with pytest.raises(ValueError):
-        empty_context.plan(plan)
+        empty_context.register_plan(plan)
 
 
 def test_add_plan_from_module(empty_context: BlueskyContext) -> None:
@@ -151,14 +151,14 @@ def test_add_plan_from_module(empty_context: BlueskyContext) -> None:
 
 
 def test_add_named_device(empty_context: BlueskyContext, sim_motor: SynAxis) -> None:
-    empty_context.device(sim_motor)
+    empty_context.register_device(sim_motor)
     assert empty_context.devices[SIM_MOTOR_NAME] is sim_motor
 
 
 def test_add_nameless_device(
     empty_context: BlueskyContext, some_configurable: SomeConfigurable
 ) -> None:
-    empty_context.device(some_configurable, "conf")
+    empty_context.register_device(some_configurable, "conf")
     assert empty_context.devices["conf"] is some_configurable
 
 
@@ -167,13 +167,13 @@ def test_add_nameless_device_without_override(
     some_configurable: SomeConfigurable,
 ) -> None:
     with pytest.raises(KeyError):
-        empty_context.device(some_configurable)
+        empty_context.register_device(some_configurable)
 
 
 def test_override_device_name(
     empty_context: BlueskyContext, sim_motor: SynAxis
 ) -> None:
-    empty_context.device(sim_motor, "foo")
+    empty_context.register_device(sim_motor, "foo")
     assert empty_context.devices["foo"] is sim_motor
 
 
@@ -246,12 +246,12 @@ def test_lookup_non_device(devicey_context: BlueskyContext) -> None:
 
 def test_add_non_plan(empty_context: BlueskyContext) -> None:
     with pytest.raises(TypeError):
-        empty_context.plan("not a plan")  # type: ignore
+        empty_context.register_plan("not a plan")  # type: ignore
 
 
 def test_add_non_device(empty_context: BlueskyContext) -> None:
     with pytest.raises(TypeError):
-        empty_context.device("not a device")  # type: ignore
+        empty_context.register_device("not a device")  # type: ignore
 
 
 def test_add_devices_and_plans_from_modules_with_config(
@@ -361,8 +361,8 @@ def test_str_default(
     empty_context: BlueskyContext, sim_motor: SynAxis, alt_motor: SynAxis
 ):
     movable_ref = empty_context._reference(Movable)
-    empty_context.device(sim_motor)
-    empty_context.plan(has_default_reference)
+    empty_context.register_device(sim_motor)
+    empty_context.register_plan(has_default_reference)
 
     spec = empty_context._type_spec_for_function(has_default_reference)
     assert spec["m"][0] is movable_ref
@@ -371,7 +371,7 @@ def test_str_default(
     assert has_default_reference.__name__ in empty_context.plans
     model = empty_context.plans[has_default_reference.__name__].model
     assert parse_obj_as(model, {}).m is sim_motor  # type: ignore
-    empty_context.device(alt_motor)
+    empty_context.register_device(alt_motor)
     assert parse_obj_as(model, {"m": ALT_MOTOR_NAME}).m is alt_motor  # type: ignore
 
 
@@ -379,8 +379,8 @@ def test_nested_str_default(
     empty_context: BlueskyContext, sim_motor: SynAxis, alt_motor: SynAxis
 ):
     movable_ref = empty_context._reference(Movable)
-    empty_context.device(sim_motor)
-    empty_context.plan(has_default_nested_reference)
+    empty_context.register_device(sim_motor)
+    empty_context.register_plan(has_default_nested_reference)
 
     spec = empty_context._type_spec_for_function(has_default_nested_reference)
     assert spec["m"][0] == list[movable_ref]  # type: ignore
@@ -389,7 +389,7 @@ def test_nested_str_default(
     assert has_default_nested_reference.__name__ in empty_context.plans
     model = empty_context.plans[has_default_nested_reference.__name__].model
     assert parse_obj_as(model, {}).m == [sim_motor]  # type: ignore
-    empty_context.device(alt_motor)
+    empty_context.register_device(alt_motor)
     assert parse_obj_as(model, {"m": [ALT_MOTOR_NAME]}).m == [alt_motor]  # type: ignore
 
 
@@ -398,6 +398,6 @@ def test_plan_models_not_auto_camelcased(empty_context: BlueskyContext) -> None:
         if False:
             yield
 
-    empty_context.plan(a_plan)
+    empty_context.register_plan(a_plan)
     with pytest.raises(ValidationError):
         empty_context.plans[a_plan.__name__].model(fooBar=1, baz="test")

--- a/tests/worker/test_reworker.py
+++ b/tests/worker/test_reworker.py
@@ -65,8 +65,8 @@ def context(fake_device: FakeDevice) -> BlueskyContext:
     ctx_config.sources.append(
         Source(kind=SourceKind.DEVICE_FUNCTIONS, module="devices")
     )
-    ctx.plan(failing_plan)
-    ctx.device(fake_device)
+    ctx.register_plan(failing_plan)
+    ctx.register_device(fake_device)
     ctx.with_config(ctx_config)
     return ctx
 


### PR DESCRIPTION
Outlined the places where the code needs to be modify to support the requested features.

Some alignment must happen on what is the best format to store the devices that are lazy. 

I'd rather do it in the start of the PR. 
#363 and #504  would change how this works however I think that this PR is mergeable much earlier than that.

Then, on my end I think the lazy devices would be best presented as:
-    early_devices: dict[str, Device] = field(default_factory=dict)
-    lazy_devices: dict[str, Device] = field(default_factory=dict)
properties on the Context object.