### PR TITLE
Rename handler "state" to "worker_state"

### DIFF
--- a/src/blueapi/service/handler.py
+++ b/src/blueapi/service/handler.py
@@ -123,7 +123,7 @@ class Handler(BlueskyHandler):
         return self._worker.get_active_task()
 
     @property
-    def state(self) -> WorkerState:
+    def worker_state(self) -> WorkerState:
         return self._worker.state
 
     def pause_worker(self, defer: bool | None) -> None:

--- a/src/blueapi/service/handler_base.py
+++ b/src/blueapi/service/handler_base.py
@@ -66,7 +66,7 @@ class BlueskyHandler(ABC):
 
     @property
     @abstractmethod
-    def state(self) -> WorkerState:
+    def worker_state(self) -> WorkerState:
         """State of the worker"""
 
     @abstractmethod

--- a/src/blueapi/service/main.py
+++ b/src/blueapi/service/main.py
@@ -256,7 +256,7 @@ def get_active_task(handler: BlueskyHandler = Depends(get_handler)) -> WorkerTas
 @app.get("/worker/state")
 def get_state(handler: BlueskyHandler = Depends(get_handler)) -> WorkerState:
     """Get the State of the Worker"""
-    return handler.state
+    return handler.worker_state
 
 
 # Map of current_state: allowed new_states
@@ -304,7 +304,7 @@ def set_state(
         - If reason is set, the reason will be passed as the reason for the Run failure.
     - **All other transitions return 400: Bad Request**
     """
-    current_state = handler.state
+    current_state = handler.worker_state
     new_state = state_change_request.new_state
     if (
         current_state in _ALLOWED_TRANSITIONS
@@ -325,7 +325,7 @@ def set_state(
     else:
         response.status_code = status.HTTP_400_BAD_REQUEST
 
-    return handler.state
+    return handler.worker_state
 
 
 def start(config: ApplicationConfig):

--- a/src/blueapi/service/subprocess_handler.py
+++ b/src/blueapi/service/subprocess_handler.py
@@ -93,8 +93,8 @@ class SubprocessHandler(BlueskyHandler):
         return self._run_in_subprocess(active_task)
 
     @property
-    def state(self) -> WorkerState:
-        return self._run_in_subprocess(state)
+    def worker_state(self) -> WorkerState:
+        return self._run_in_subprocess(worker_state)
 
     def pause_worker(self, defer: bool | None) -> None:
         return self._run_in_subprocess(pause_worker, [defer])
@@ -156,8 +156,8 @@ def active_task() -> TrackableTask | None:
     return get_handler().active_task
 
 
-def state() -> WorkerState:
-    return get_handler().state
+def worker_state() -> WorkerState:
+    return get_handler().worker_state
 
 
 def pause_worker(defer: bool | None) -> None:

--- a/tests/service/test_subprocess_handler.py
+++ b/tests/service/test_subprocess_handler.py
@@ -57,7 +57,7 @@ def test_reload():
 def test_raises_if_not_started():
     sp_handler = SubprocessHandler()
     with pytest.raises(HandlerNotStartedError):
-        assert sp_handler.state is None
+        assert sp_handler.worker_state is None
 
 
 class DummyHandler(BlueskyHandler):
@@ -105,7 +105,7 @@ class DummyHandler(BlueskyHandler):
         return None
 
     @property
-    def state(self) -> WorkerState:
+    def worker_state(self) -> WorkerState:
         return WorkerState.IDLE
 
     def pause_worker(self, defer: bool | None) -> None: ...
@@ -171,7 +171,7 @@ def test_method_routing(get_handler_mock: MagicMock):
 
     assert sp_handler.active_task == dummy_handler.active_task
 
-    assert sp_handler.state == dummy_handler.state
+    assert sp_handler.worker_state == dummy_handler.worker_state
 
     sp_handler.pause_worker(True)
 


### PR DESCRIPTION
It is the worker state rather than the overall state of blueapi.

The "state" name may be used to replace the current "initialized" in order to provide more context about the "environment"

Prerequisite to #514.