### PR TITLE
Correct generated schema for Reference types

### DIFF
--- a/src/blueapi/core/context.py
+++ b/src/blueapi/core/context.py
@@ -202,7 +202,9 @@ class BlueskyContext:
                     cls, field_schema: dict[str, Any], field: ModelField | None
                 ):
                     if field:
-                        field_schema.update({"type": repr(target)})
+                        field_schema.update(
+                            {"type": f"{target.__module__}.{target.__qualname__}"}
+                        )
 
             self._reference_cache[target] = Reference
 

--- a/src/blueapi/core/context.py
+++ b/src/blueapi/core/context.py
@@ -202,7 +202,7 @@ class BlueskyContext:
                     cls, field_schema: dict[str, Any], field: ModelField | None
                 ):
                     if field:
-                        field_schema.update({field.name: repr(target)})
+                        field_schema.update({"type": repr(target)})
 
             self._reference_cache[target] = Reference
 

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -121,6 +121,20 @@ def test_add_plan(empty_context: BlueskyContext, plan: PlanGenerator) -> None:
     assert plan.__name__ in empty_context.plans
 
 
+def test_generated_schema(
+    empty_context: BlueskyContext,
+):
+    def demo_plan(foo: int, mov: Movable) -> MsgGenerator:  # type: ignore
+        ...
+
+    empty_context.plan(demo_plan)
+    schema = empty_context.plans["demo_plan"].model.schema()
+    assert schema["properties"] == {
+        "foo": {"title": "Foo", "type": "integer"},
+        "mov": {"title": "Mov", "type": repr(Movable)},
+    }
+
+
 @pytest.mark.parametrize(
     "plan", [has_typeless_param, has_typed_and_typeless_params, has_typeless_params]
 )

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -131,7 +131,7 @@ def test_generated_schema(
     schema = empty_context.plans["demo_plan"].model.schema()
     assert schema["properties"] == {
         "foo": {"title": "Foo", "type": "integer"},
-        "mov": {"title": "Mov", "type": repr(Movable)},
+        "mov": {"title": "Mov", "type": "bluesky.protocols.Movable"},
     }
 
 

--- a/tests/service/test_rest_api.py
+++ b/tests/service/test_rest_api.py
@@ -110,7 +110,7 @@ def test_get_plan_with_device_reference(handler: Handler, client: TestClient) ->
                         "title": "Delay",
                     },
                     "detectors": {
-                        "items": {"type": "<class " "'bluesky.protocols.Readable'>"},
+                        "items": {"type": "bluesky.protocols.Readable"},
                         "title": "Detectors",
                         "type": "array",
                     },
@@ -133,7 +133,7 @@ def test_get_plan_with_device_reference(handler: Handler, client: TestClient) ->
                     "title": "Delay",
                 },
                 "detectors": {
-                    "items": {"type": "<class " "'bluesky.protocols.Readable'>"},
+                    "items": {"type": "bluesky.protocols.Readable"},
                     "title": "Detectors",
                     "type": "array",
                 },

--- a/tests/service/test_rest_api.py
+++ b/tests/service/test_rest_api.py
@@ -110,9 +110,7 @@ def test_get_plan_with_device_reference(handler: Handler, client: TestClient) ->
                         "title": "Delay",
                     },
                     "detectors": {
-                        "items": {
-                            "_detectors": "<class " "'bluesky.protocols.Readable'>"
-                        },
+                        "items": {"type": "<class " "'bluesky.protocols.Readable'>"},
                         "title": "Detectors",
                         "type": "array",
                     },
@@ -135,7 +133,7 @@ def test_get_plan_with_device_reference(handler: Handler, client: TestClient) ->
                     "title": "Delay",
                 },
                 "detectors": {
-                    "items": {"_detectors": "<class " "'bluesky.protocols.Readable'>"},
+                    "items": {"type": "<class " "'bluesky.protocols.Readable'>"},
                     "title": "Detectors",
                     "type": "array",
                 },


### PR DESCRIPTION
I think this resolves the plan schemas returned from the plans endpoint. Do we
want to include some field in the schema to mark that the field should be a
reference rather than the value itself?
