### PR TITLE
Add formatting options to controller CLI output

### DIFF
--- a/src/blueapi/cli/cli.py
+++ b/src/blueapi/cli/cli.py
@@ -12,7 +12,7 @@ from requests.exceptions import ConnectionError
 
 from blueapi import __version__
 from blueapi.cli.event_bus_client import BlueskyRemoteError, EventBusClient
-from blueapi.cli.format import OutputFormat, format_for_name
+from blueapi.cli.format import OutputFormat
 from blueapi.config import ApplicationConfig, ConfigLoader
 from blueapi.core import DataEvent
 from blueapi.messaging import MessageContext
@@ -90,6 +90,7 @@ def start_application(obj: dict):
 
 @main.group()
 @click.option(
+    "-o",
     "--output",
     type=click.Choice([o.name.lower() for o in OutputFormat]),
     default="compact",
@@ -104,7 +105,7 @@ def controller(ctx: click.Context, output: str) -> None:
 
     ctx.ensure_object(dict)
     config: ApplicationConfig = ctx.obj["config"]
-    ctx.obj["fmt"] = format_for_name(output)
+    ctx.obj["fmt"] = OutputFormat(output)
     ctx.obj["rest_client"] = BlueapiRestClient(config.api)
 
 

--- a/src/blueapi/cli/cli.py
+++ b/src/blueapi/cli/cli.py
@@ -12,6 +12,7 @@ from requests.exceptions import ConnectionError
 
 from blueapi import __version__
 from blueapi.cli.event_bus_client import BlueskyRemoteError, EventBusClient
+from blueapi.cli.format import OutputFormat, format_for_name
 from blueapi.config import ApplicationConfig, ConfigLoader
 from blueapi.core import DataEvent
 from blueapi.messaging import MessageContext
@@ -88,8 +89,13 @@ def start_application(obj: dict):
 
 
 @main.group()
+@click.option(
+    "--output",
+    type=click.Choice([o.name.lower() for o in OutputFormat]),
+    default="compact",
+)
 @click.pass_context
-def controller(ctx: click.Context) -> None:
+def controller(ctx: click.Context, output: str) -> None:
     """Client utility for controlling and introspecting the worker"""
 
     if ctx.invoked_subcommand is None:
@@ -98,6 +104,7 @@ def controller(ctx: click.Context) -> None:
 
     ctx.ensure_object(dict)
     config: ApplicationConfig = ctx.obj["config"]
+    ctx.obj["fmt"] = format_for_name(output)
     ctx.obj["rest_client"] = BlueapiRestClient(config.api)
 
 
@@ -118,7 +125,7 @@ def check_connection(func):
 def get_plans(obj: dict) -> None:
     """Get a list of plans available for the worker to use"""
     client: BlueapiRestClient = obj["rest_client"]
-    pprint(client.get_plans().dict())
+    obj["fmt"].display(client.get_plans())
 
 
 @controller.command(name="devices")
@@ -127,7 +134,7 @@ def get_plans(obj: dict) -> None:
 def get_devices(obj: dict) -> None:
     """Get a list of devices available for the worker to use"""
     client: BlueapiRestClient = obj["rest_client"]
-    pprint(client.get_devices().dict())
+    obj["fmt"].display(client.get_devices())
 
 
 @controller.command(name="listen")
@@ -230,7 +237,7 @@ def get_state(obj: dict) -> None:
     """Print the current state of the worker"""
 
     client: BlueapiRestClient = obj["rest_client"]
-    pprint(client.get_state())
+    print(client.get_state().name)
 
 
 @controller.command(name="pause")

--- a/src/blueapi/cli/format.py
+++ b/src/blueapi/cli/format.py
@@ -1,4 +1,3 @@
-from _typeshed import SupportsWrite
 import builtins
 import enum
 import json
@@ -7,7 +6,7 @@ import textwrap
 from functools import partial
 from pprint import pprint
 from textwrap import dedent, indent
-from typing import Any
+from typing import Any, TextIO
 
 from pydantic import BaseModel
 
@@ -15,7 +14,7 @@ from blueapi.service.model import DeviceResponse, PlanResponse
 
 FALLBACK = pprint
 
-Stream = SupportsWrite[str] | None
+Stream = TextIO | None
 
 
 class OutputFormat(str, enum.Enum):

--- a/src/blueapi/cli/format.py
+++ b/src/blueapi/cli/format.py
@@ -50,7 +50,7 @@ def display_full(obj: Any, stream: Stream):
                 for proto in dev.protocols:
                     print("    " + proto)
         case other:
-            FALLBACK(other)
+            FALLBACK(other, stream=stream)
 
 
 def display_json(obj: Any, stream: Stream):
@@ -84,7 +84,7 @@ def display_compact(obj: Any, stream: Stream):
                 print(dev.name)
                 print(indent(textwrap.fill(", ".join(dev.protocols), 80), "    "))
         case other:
-            FALLBACK(other)
+            FALLBACK(other, stream=stream)
 
 
 def _describe_type(spec: dict[Any, Any], required: bool = False):

--- a/src/blueapi/cli/format.py
+++ b/src/blueapi/cli/format.py
@@ -1,0 +1,119 @@
+import enum
+import json
+import textwrap
+from pprint import pprint
+from textwrap import dedent, indent
+
+from blueapi.service.model import DeviceResponse, PlanResponse
+
+FALLBACK = pprint
+
+
+class OutputFormat(enum.Enum):
+    JSON = enum.auto()
+    FULL = enum.auto()
+    COMPACT = enum.auto()
+    PPRINT = enum.auto()
+
+    def display(self, obj):
+        match self:
+            case OutputFormat.FULL:
+                display_full(obj)
+            case OutputFormat.COMPACT:
+                display_compact(obj)
+            case OutputFormat.JSON:
+                display_json(obj)
+            case OutputFormat.PPRINT:
+                display_pprint(obj)
+
+
+def display_full(obj):
+    match obj:
+        case PlanResponse(plans=plans):
+            for plan in plans:
+                print(plan.name)
+                if desc := plan.description:
+                    print(indent(dedent(desc).strip(), "    "))
+                if schema := plan.parameter_schema:
+                    print("    Schema")
+                    print(indent(json.dumps(schema, indent=2), "        "))
+        case DeviceResponse(devices=devices):
+            for dev in devices:
+                print(dev.name)
+                for proto in dev.protocols:
+                    print("    " + proto)
+        case other:
+            FALLBACK(other)
+
+
+def display_json(obj):
+    match obj:
+        case PlanResponse(plans=plans):
+            print(json.dumps([p.dict() for p in plans], indent=2))
+        case DeviceResponse(devices=devices):
+            print(json.dumps([d.dict() for d in devices], indent=2))
+        case _:
+            print(json.dumps(obj))
+
+
+def display_compact(obj):
+    match obj:
+        case PlanResponse(plans=plans):
+            for plan in plans:
+                print(plan.name)
+                if desc := plan.description:
+                    print(indent(dedent(desc.split("\n\n")[0].strip("\n")), "    "))
+                if schema := plan.parameter_schema:
+                    print("    Args")
+                    for arg, spec in schema.get("properties", {}).items():
+                        req = arg in schema.get("required", {})
+                        print(f"      {arg}={_describe_type(spec, req)}")
+        case DeviceResponse(devices=devices):
+            for dev in devices:
+                print(dev.name)
+                print(indent(textwrap.fill(", ".join(dev.protocols), 80), "    "))
+        case other:
+            FALLBACK(other)
+
+
+def display_pprint(obj):
+    match obj:
+        case PlanResponse(plans=plans):
+            pprint([plan.dict() for plan in plans])
+        case DeviceResponse(devices=devs):
+            pprint([dev.dict() for dev in devs])
+        case _:
+            FALLBACK(obj)
+
+
+def format_for_name(name: str) -> OutputFormat:
+    match name.lower():
+        case "json":
+            return OutputFormat.JSON
+        case "compact":
+            return OutputFormat.COMPACT
+        case "pprint":
+            return OutputFormat.PPRINT
+        case "full":
+            return OutputFormat.FULL
+        case name:
+            raise ValueError(f"Format '{name}' not recognised")
+
+
+def _describe_type(spec, required=False):
+    disp = ""
+    match spec.get("type"):
+        case None:
+            if all_of := spec.get("allOf"):
+                items = (_describe_type(f, True) for f in all_of)
+                disp += f'({", ".join(items)})'
+            else:
+                disp += "Any"
+        case "array":
+            element = spec.get("items", {}).get("type", "Any")
+            disp += f"[{element}]"
+        case other:
+            disp += other
+    if required:
+        disp += " (Required)"
+    return disp

--- a/src/blueapi/cli/format.py
+++ b/src/blueapi/cli/format.py
@@ -92,8 +92,8 @@ def _describe_type(spec: dict[Any, Any], required: bool = False):
     match spec.get("type"):
         case None:
             if all_of := spec.get("allOf"):
-                items = (_describe_type(f, True) for f in all_of)
-                disp += f'({", ".join(items)})'
+                items = (_describe_type(f, False) for f in all_of)
+                disp += f'{" & ".join(items)}'
             else:
                 disp += "Any"
         case "array":

--- a/src/blueapi/cli/format.py
+++ b/src/blueapi/cli/format.py
@@ -1,3 +1,4 @@
+from _typeshed import SupportsWrite
 import builtins
 import enum
 import json
@@ -6,6 +7,7 @@ import textwrap
 from functools import partial
 from pprint import pprint
 from textwrap import dedent, indent
+from typing import Any
 
 from pydantic import BaseModel
 
@@ -13,13 +15,15 @@ from blueapi.service.model import DeviceResponse, PlanResponse
 
 FALLBACK = pprint
 
+Stream = SupportsWrite[str] | None
+
 
 class OutputFormat(str, enum.Enum):
     JSON = "json"
     FULL = "full"
     COMPACT = "compact"
 
-    def display(self, obj, out=None):
+    def display(self, obj: Any, out: Stream = None):
         out = out or sys.stdout
         match self:
             case OutputFormat.FULL:
@@ -30,7 +34,7 @@ class OutputFormat(str, enum.Enum):
                 display_json(obj, out)
 
 
-def display_full(obj, stream):
+def display_full(obj: Any, stream: Stream):
     print = partial(builtins.print, file=stream)
     match obj:
         case PlanResponse(plans=plans):
@@ -50,7 +54,7 @@ def display_full(obj, stream):
             FALLBACK(other)
 
 
-def display_json(obj, stream):
+def display_json(obj: Any, stream: Stream):
     print = partial(builtins.print, file=stream)
     match obj:
         case PlanResponse(plans=plans):
@@ -63,7 +67,7 @@ def display_json(obj, stream):
             print(json.dumps(obj))
 
 
-def display_compact(obj, stream):
+def display_compact(obj: Any, stream: Stream):
     print = partial(builtins.print, file=stream)
     match obj:
         case PlanResponse(plans=plans):
@@ -84,7 +88,7 @@ def display_compact(obj, stream):
             FALLBACK(other)
 
 
-def _describe_type(spec, required=False):
+def _describe_type(spec: dict[Any, Any], required: bool = False):
     disp = ""
     match spec.get("type"):
         case None:

--- a/src/blueapi/startup/example_plans.py
+++ b/src/blueapi/startup/example_plans.py
@@ -14,6 +14,7 @@ def stp_snapshot(
     """
     Moves devices for pressure and temperature (defaults fetched from the context)
     and captures a single frame from a collection of devices
+
     Args:
         detectors (List[Readable]): A list of devices to read while the sample is at STP
         temperature (Optional[Movable]): A device controlling temperature of the sample,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 import responses
+from textwrap import dedent
 from click.testing import CliRunner
 from fastapi.testclient import TestClient
 from pydantic import BaseModel, ValidationError
@@ -94,21 +95,19 @@ def test_get_plans_and_devices(
     plans = runner.invoke(main, ["controller", "plans"])
 
     assert (
-        plans.output == "{'plans': [{'description': None,\n"
-        "            'name': 'my-plan',\n"
-        "            'parameter_schema': {'properties': {'id': {'title': 'Id',\n"
-        "                                                       'type': 'string'}},\n"
-        "                                 'required': ['id'],\n"
-        "                                 'title': 'MyModel',\n"
-        "                                 'type': 'object'}}]}\n"
-    )
+        plans.output == dedent("""\
+                my-plan
+                    Args
+                      id=string (Required)
+                """)
+        )
 
     # Setup requests.get call to return the output of the FastAPI call for devices.
     # Call the CLI function and check the output - expect nothing as no devices set.
     handler._context.devices = {}
     mock_requests.return_value = client.get("/devices")
     unset_devices = runner.invoke(main, ["controller", "devices"])
-    assert unset_devices.output == "{'devices': []}\n"
+    assert unset_devices.output == ""
 
     # Put a device in handler.context manually.
     device = MyDevice("my-device")
@@ -120,8 +119,10 @@ def test_get_plans_and_devices(
     devices = runner.invoke(main, ["controller", "devices"])
 
     assert (
-        devices.output
-        == "{'devices': [{'name': 'my-device', 'protocols': ['HasName']}]}\n"
+        devices.output == dedent("""\
+            my-device
+                HasName
+            """)
     )
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,5 @@
-from collections.abc import Mapping
 import json
+from collections.abc import Mapping
 from dataclasses import dataclass
 from io import StringIO
 from textwrap import dedent

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -489,11 +489,6 @@ def test_device_output_formatting():
             """)
     assert output.getvalue() == full
 
-    output = StringIO()
-    OutputFormat.PPRINT.display(devices, out=output)
-    pretty = "[{'name': 'my-device', 'protocols': ['HasName']}]\n"
-    assert output.getvalue() == pretty
-
 
 def test_plan_output_formatting():
     """Test for alternative plan output formats"""
@@ -571,15 +566,3 @@ def test_plan_output_formatting():
                     }
             """)
     assert output.getvalue() == full
-
-    output = StringIO()
-    OutputFormat.PPRINT.display(plans, out=output)
-    pretty = dedent("""\
-        [{'description': 'Summary of description\\n\\nRest of description\\n',
-          'name': 'my-plan',
-          'parameter_schema': {'properties': {'id': {'title': 'Id', 'type': 'string'}},
-                               'required': ['id'],
-                               'title': 'MyModel',
-                               'type': 'object'}}]
-        """)
-    assert output.getvalue() == pretty


### PR DESCRIPTION
Defaults to compact view for now.

Offers
* ~pprint - the current default~
* full - everything in a mostly human readable form
* json - valid json
* compact - most of the information that's likely to be useful for non-machines

Testable by passing the `--output` flag to the `controller` subcommand

```bash
python -m blueapi controller --output json devices
python -m blueapi controller --output json plans
```
