### PR TITLE
Use equality instead of identity to compare types

### DIFF
--- a/src/blueapi/core/bluesky_types.py
+++ b/src/blueapi/core/bluesky_types.py
@@ -75,7 +75,7 @@ def _follows_bluesky_protocols(obj: Any) -> bool:
 
 def is_bluesky_plan_generator(func: PlanGenerator) -> bool:
     try:
-        return get_type_hints(func).get("return") is MsgGenerator
+        return get_type_hints(func).get("return") == MsgGenerator
     except TypeError:
         # get_type_hints fails on some objects (such as Union or Optional)
         return False


### PR DESCRIPTION
In some cases, possibly when MsgGenerator is defined or imported from
different modules, the types can be equivalent but are not the same
instance. In these cases, the identity check would fail and some plans
would be excluded where they shouldn't be. Using equality checks instead
mean it shouldn't matter where the MsgGenerator type was defined as all
instances should be equal.
