### PR TITLE
Extend formatting options to listen subcommand

### DIFF
--- a/src/blueapi/cli/cli.py
+++ b/src/blueapi/cli/cli.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import sys
 from functools import wraps
 from pathlib import Path
 from pprint import pprint
@@ -158,20 +159,23 @@ def listen_to_events(obj: dict) -> None:
     else:
         raise RuntimeError("Message bus needs to be configured")
 
+    fmt = obj["fmt"]
+
     def on_event(
         event: WorkerEvent | ProgressEvent | DataEvent,
         context: MessageContext,
     ) -> None:
-        converted = json.dumps(event.model_dump(), indent=2)
-        print(converted)
+        fmt.display(event)
 
     print(
         "Subscribing to all bluesky events from "
-        f"{config.stomp.host}:{config.stomp.port}"
+        f"{config.stomp.host}:{config.stomp.port}",
+        file=sys.stderr,
     )
     with event_bus_client:
         event_bus_client.subscribe_to_all_events(on_event)
-        input("Press enter to exit")
+        print("Press enter to exit", file=sys.stderr)
+        input()
 
 
 @controller.command(name="run")

--- a/src/blueapi/cli/format.py
+++ b/src/blueapi/cli/format.py
@@ -62,9 +62,9 @@ def display_full(obj: Any, stream: Stream):
                     print("    " + proto)
         case DataEvent(name=name, doc=doc):
             print(f"{name.title()}: {fmt_dict(doc)}")
-        case WorkerEvent(state=state, task_status=task):
+        case WorkerEvent(state=st, task_status=task):
             print(
-                f"WorkerEvent: {state.name}{fmt_dict(task.model_dump() if task else {})}"
+                f"WorkerEvent: {st.name}{fmt_dict(task.model_dump() if task else {})}"
             )
         case ProgressEvent():
             print(f"Progress:{fmt_dict(obj.model_dump())}")

--- a/src/blueapi/cli/format.py
+++ b/src/blueapi/cli/format.py
@@ -106,7 +106,7 @@ def display_compact(obj: Any, stream: Stream):
         case DataEvent(name=name):
             print(f"Data Event: {name}")
         case WorkerEvent(state=state):
-            print(f"Worker Event: {state}")
+            print(f"Worker Event: {state.name}")
         case ProgressEvent(statuses=stats):
             prog = (
                 max(100 * (s.percentage or 0) for s in stats.values())

--- a/src/blueapi/cli/format.py
+++ b/src/blueapi/cli/format.py
@@ -106,9 +106,13 @@ def display_compact(obj: Any, stream: Stream):
         case DataEvent(name=name):
             print(f"Data Event: {name}")
         case WorkerEvent(state=state):
-            print(f"Worker state: {state}")
+            print(f"Worker Event: {state}")
         case ProgressEvent(statuses=stats):
-            prog = max(100 * (s.percentage or 0) for s in stats.values()) or "???"
+            prog = (
+                max(100 * (s.percentage or 0) for s in stats.values())
+                if stats
+                else "???"
+            )
             print(f"Progress: {prog}%")
         case other:
             FALLBACK(other, stream=stream)

--- a/src/blueapi/cli/format.py
+++ b/src/blueapi/cli/format.py
@@ -63,7 +63,9 @@ def display_full(obj: Any, stream: Stream):
         case DataEvent(name=name, doc=doc):
             print(f"{name.title()}: {fmt_dict(doc)}")
         case WorkerEvent(state=state, task_status=task):
-            print(f"WorkerEvent: {state}{fmt_dict(task.model_dump() if task else {})}")
+            print(
+                f"WorkerEvent: {state.name}{fmt_dict(task.model_dump() if task else {})}"
+            )
         case ProgressEvent():
             print(f"Progress:{fmt_dict(obj.model_dump())}")
         case BaseModel():

--- a/src/blueapi/cli/format.py
+++ b/src/blueapi/cli/format.py
@@ -23,9 +23,9 @@ Stream = TextIO | None
 def fmt_dict(t: dict[str, Any] | Any, ind: int = 1) -> str:
     """Format a (possibly nested) dict into a human readable tree"""
     if not isinstance(t, dict):
-        return t
+        return f" {t}"
     pre = " " * (ind * 4)
-    return NL + NL.join(f"{pre}{k}: {fmt_dict(v, ind+1)}" for k, v in t.items() if v)
+    return NL + NL.join(f"{pre}{k}:{fmt_dict(v, ind+1)}" for k, v in t.items() if v)
 
 
 class OutputFormat(str, enum.Enum):
@@ -61,7 +61,7 @@ def display_full(obj: Any, stream: Stream):
                 for proto in dev.protocols:
                     print("    " + proto)
         case DataEvent(name=name, doc=doc):
-            print(f"{name.title()}: {fmt_dict(doc)}")
+            print(f"{name.title()}:{fmt_dict(doc)}")
         case WorkerEvent(state=st, task_status=task):
             print(
                 f"WorkerEvent: {st.name}{fmt_dict(task.model_dump() if task else {})}"

--- a/src/blueapi/cli/format.py
+++ b/src/blueapi/cli/format.py
@@ -67,7 +67,7 @@ def display_full(obj: Any, stream: Stream):
         case ProgressEvent():
             print(f"Progress:{fmt_dict(obj.model_dump())}")
         case BaseModel():
-            print(obj.__class__.__name__, end='')
+            print(obj.__class__.__name__, end="")
             print(fmt_dict(obj.model_dump()))
         case other:
             FALLBACK(other, stream=stream)
@@ -108,7 +108,7 @@ def display_compact(obj: Any, stream: Stream):
         case WorkerEvent(state=state):
             print(f"Worker state: {state}")
         case ProgressEvent(statuses=stats):
-            prog = max(100 * (s.percentage or 0)  for s in stats.values()) or "???"
+            prog = max(100 * (s.percentage or 0) for s in stats.values()) or "???"
             print(f"Progress: {prog}%")
         case other:
             FALLBACK(other, stream=stream)

--- a/tests/unit_tests/test_cli.py
+++ b/tests/unit_tests/test_cli.py
@@ -551,13 +551,11 @@ def test_event_formatting():
             """"errors": [], "warnings": []}\n"""
         ),
     )
-    _assert_matching_formatting(
-        OutputFormat.COMPACT, worker, "Worker Event: WorkerState.RUNNING\n"
-    )
+    _assert_matching_formatting(OutputFormat.COMPACT, worker, "Worker Event: RUNNING\n")
     _assert_matching_formatting(
         OutputFormat.FULL,
         worker,
-        "WorkerEvent: WorkerState.RUNNING\n    task_id: count\n",
+        "WorkerEvent: RUNNING\n    task_id: count\n",
     )
 
     _assert_matching_formatting(

--- a/tests/unit_tests/test_cli.py
+++ b/tests/unit_tests/test_cli.py
@@ -165,10 +165,10 @@ def test_valid_stomp_config_for_listener(
         ],
         input="\n",
     )
-    assert (
-        result.output
-        == "Subscribing to all bluesky events from localhost:61613\nPress enter to exit\n"
-    )
+    assert result.output == dedent("""\
+                Subscribing to all bluesky events from localhost:61613
+                Press enter to exit
+                """)
     assert result.exit_code == 0
 
 

--- a/tests/unit_tests/test_cli.py
+++ b/tests/unit_tests/test_cli.py
@@ -167,7 +167,7 @@ def test_valid_stomp_config_for_listener(
     )
     assert (
         result.output
-        == "Subscribing to all bluesky events from localhost:61613\nPress enter to exit"
+        == "Subscribing to all bluesky events from localhost:61613\nPress enter to exit\n"
     )
     assert result.exit_code == 0
 
@@ -528,19 +528,7 @@ def test_unknown_object_formatting():
 def test_generic_base_model_formatting():
     output = StringIO()
     obj = ExtendedModel(name="foo", keys=[1, 2, 3], metadata={"fizz": "buzz"})
-    exp = dedent("""\
-            {
-              "name": "foo",
-              "keys": [
-                1,
-                2,
-                3
-              ],
-              "metadata": {
-                "fizz": "buzz"
-              }
-            }
-            """)
+    exp = '{"name": "foo", "keys": [1, 2, 3], "metadata": {"fizz": "buzz"}}\n'
     OutputFormat.JSON.display(obj, output)
     assert exp == output.getvalue()
 

--- a/tests/unit_tests/test_cli.py
+++ b/tests/unit_tests/test_cli.py
@@ -349,13 +349,8 @@ def test_device_output_formatting():
                     HasName
                 """)
 
-    output = StringIO()
-    OutputFormat.COMPACT.display(devices, out=output)
-    assert output.getvalue() == compact
+    _assert_matching_formatting(OutputFormat.COMPACT, devices, compact)
 
-    # json outputs valid json
-    output = StringIO()
-    OutputFormat.JSON.display(devices, out=output)
     json_out = dedent("""\
                 [
                   {
@@ -366,16 +361,14 @@ def test_device_output_formatting():
                   }
                 ]
                 """)
-    assert output.getvalue() == json_out
-    _ = json.loads(output.getvalue())
+    _assert_matching_formatting(OutputFormat.JSON, devices, json_out)
+    _ = json.loads(json_out)
 
-    output = StringIO()
-    OutputFormat.FULL.display(devices, out=output)
     full = dedent("""\
             my-device
                 HasName
             """)
-    assert output.getvalue() == full
+    _assert_matching_formatting(OutputFormat.FULL, devices, full)
 
 
 class ExtendedModel(BaseModel):
@@ -407,13 +400,8 @@ def test_plan_output_formatting():
                       metadata=object
                 """)
 
-    output = StringIO()
-    OutputFormat.COMPACT.display(plans, out=output)
-    assert output.getvalue() == compact
+    _assert_matching_formatting(OutputFormat.COMPACT, plans, compact)
 
-    # json outputs valid json
-    output = StringIO()
-    OutputFormat.JSON.display(plans, out=output)
     json_out = dedent("""\
             [
               {
@@ -458,11 +446,9 @@ def test_plan_output_formatting():
               }
             ]
                 """)
-    assert output.getvalue() == json_out
-    _ = json.loads(output.getvalue())
+    _assert_matching_formatting(OutputFormat.JSON, plans, json_out)
+    _ = json.loads(json_out)
 
-    output = StringIO()
-    OutputFormat.FULL.display(plans, out=output)
     full = dedent("""\
         my-plan
             Summary of description
@@ -506,7 +492,7 @@ def test_plan_output_formatting():
                   "type": "object"
                 }
             """)
-    assert output.getvalue() == full
+    _assert_matching_formatting(OutputFormat.FULL, plans, full)
 
 
 def test_event_formatting():
@@ -570,19 +556,13 @@ def test_event_formatting():
 def test_unknown_object_formatting():
     demo = {"foo": 42, "bar": ["hello", "World"]}
 
-    output = StringIO()
-    OutputFormat.JSON.display(demo, output)
     exp = """{"foo": 42, "bar": ["hello", "World"]}\n"""
-    assert exp == output.getvalue()
+    _assert_matching_formatting(OutputFormat.JSON, demo, exp)
 
-    output = StringIO()
-    OutputFormat.COMPACT.display(demo, output)
     exp = """{'bar': ['hello', 'World'], 'foo': 42}\n"""
-    assert exp == output.getvalue()
+    _assert_matching_formatting(OutputFormat.COMPACT, demo, exp)
 
-    output = StringIO()
-    OutputFormat.FULL.display(demo, output)
-    assert exp == output.getvalue()
+    _assert_matching_formatting(OutputFormat.FULL, demo, exp)
 
 
 def test_dict_formatting():
@@ -595,24 +575,18 @@ def test_dict_formatting():
 
 
 def test_generic_base_model_formatting():
-    output = StringIO()
-    obj = ExtendedModel(name="foo", keys=[1, 2, 3], metadata={"fizz": "buzz"})
-    exp = '{"name": "foo", "keys": [1, 2, 3], "metadata": {"fizz": "buzz"}}\n'
-    OutputFormat.JSON.display(obj, output)
-    assert exp == output.getvalue()
+    model = ExtendedModel(name="demo", keys=[1, 2, 3], metadata={"fizz": "buzz"})
+    exp = '{"name": "demo", "keys": [1, 2, 3], "metadata": {"fizz": "buzz"}}\n'
+    _assert_matching_formatting(OutputFormat.JSON, model, exp)
 
-    model = ExtendedModel(
-        name="demo_model", keys=[1, 2, 3], metadata={"foo": "bar", "fizz": "buzz"}
-    )
     _assert_matching_formatting(
         OutputFormat.FULL,
         model,
         dedent("""\
             ExtendedModel
-                name: demo_model
+                name: demo
                 keys: [1, 2, 3]
                 metadata:
-                    foo: bar
                     fizz: buzz
             """),
     )

--- a/tests/unit_tests/test_cli.py
+++ b/tests/unit_tests/test_cli.py
@@ -533,13 +533,13 @@ def test_event_formatting():
     _assert_matching_formatting(
         OutputFormat.FULL,
         data,
-        (
-            "Start: \n"
-            "    foo: bar\n"
-            "    fizz: \n"
-            "        buzz: (1, 2, 3)\n"
-            "        hello: world\n"
-        ),
+        dedent("""\
+            Start:
+                foo: bar
+                fizz:
+                    buzz: (1, 2, 3)
+                    hello: world
+            """),
     )
 
     _assert_matching_formatting(
@@ -587,11 +587,11 @@ def test_unknown_object_formatting():
 
 def test_dict_formatting():
     demo = {"name": "foo", "keys": [1, 2, 3], "metadata": {"fizz": "buzz"}}
-    exp = """\nname: foo\nkeys: [1, 2, 3]\nmetadata: \n    fizz: buzz"""
+    exp = """\nname: foo\nkeys: [1, 2, 3]\nmetadata:\n    fizz: buzz"""
     assert fmt_dict(demo, 0) == exp
 
     demo = "not a dict"
-    assert fmt_dict(demo, 0) == "not a dict"
+    assert fmt_dict(demo, 0) == " not a dict"
 
 
 def test_generic_base_model_formatting():
@@ -600,6 +600,22 @@ def test_generic_base_model_formatting():
     exp = '{"name": "foo", "keys": [1, 2, 3], "metadata": {"fizz": "buzz"}}\n'
     OutputFormat.JSON.display(obj, output)
     assert exp == output.getvalue()
+
+    model = ExtendedModel(
+        name="demo_model", keys=[1, 2, 3], metadata={"foo": "bar", "fizz": "buzz"}
+    )
+    _assert_matching_formatting(
+        OutputFormat.FULL,
+        model,
+        dedent("""\
+            ExtendedModel
+                name: demo_model
+                keys: [1, 2, 3]
+                metadata:
+                    foo: bar
+                    fizz: buzz
+            """),
+    )
 
 
 @patch("blueapi.cli.cli.setup_scratch")


### PR DESCRIPTION
Listen streams a mix of WorkerEvent, ProgressEvent and DataEvent
instances for anything that the server is doing. This extends the type
handling in the format to each of these types to display the relevant
level of information for each.

Informational messages are changed to be printed to stderr so that the
main stdout output can be piped to an external application (eg jq for
json mode).
