### PR TITLE
Configure Dependabot to respect pinned dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,3 +22,6 @@ updates:
       dev-dependencies:
         patterns:
           - "*"
+    ignore:
+      - dependency-name: "pydantic"
+        versions: [">=2.0"]


### PR DESCRIPTION
Doubly pins some dependencies (in pyproject.toml and in dependabot.yaml) so that these pins will not be automatically removed by dependabot, and dependabot PRs can be consumed without losing the purposeful pinning of known incompatibilities.

See also #273 
TODO: Make issues for the other known problems to track when they are capable of being unpinned