### PR TITLE
Unpin dependency on fastapi, click

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -39,7 +39,7 @@ decorator==5.1.1
 deepmerge==1.1.1
 distlib==0.3.8
 dls-bluesky-core==0.0.3
-dls-dodal==1.29.0
+dls-dodal==1.29.2
 dnspython==2.6.1
 docopt==0.6.2
 doct==1.1.0
@@ -51,7 +51,7 @@ epicscorelibs==7.0.7.99.0.2
 event-model==1.20.0
 exceptiongroup==1.2.1
 executing==2.0.1
-fastapi==0.98.0
+fastapi==0.99.1
 fasteners==0.19
 filelock==3.15.4
 flexcache==0.3
@@ -68,7 +68,7 @@ historydict==1.2.6
 httpcore==1.0.5
 httptools==0.6.1
 httpx==0.27.0
-humanize==4.9.0
+humanize==4.10.0
 identify==2.6.0
 idna==3.7
 imageio==2.34.2
@@ -83,7 +83,7 @@ itsdangerous==2.2.0
 jedi==0.19.1
 Jinja2==3.1.4
 jinja2-ansible-filters==1.3.2
-jsonschema==4.22.0
+jsonschema==4.23.0
 jsonschema-specifications==2023.12.1
 jupyterlab_widgets==3.0.11
 kiwisolver==1.4.5
@@ -166,7 +166,7 @@ redis-json-dict==0.2.0
 referencing==0.35.1
 requests==2.32.3
 responses==0.25.3
-rpds-py==0.18.1
+rpds-py==0.19.0
 ruff==0.5.1
 scanspec==0.6.6
 setuptools-dso==2.10

--- a/docs/reference/asyncapi.yaml
+++ b/docs/reference/asyncapi.yaml
@@ -291,3 +291,4 @@ components:
           description: Estimated time remaining until operation completion, if known
           type: number
           format: float
+

--- a/docs/reference/openapi.yaml
+++ b/docs/reference/openapi.yaml
@@ -228,7 +228,7 @@ components:
 info:
   title: BlueAPI Control
   version: 0.0.5
-openapi: 3.0.2
+openapi: 3.1.0
 paths:
   /devices:
     get:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,12 +17,12 @@ dependencies = [
     "nslsii",
     "pyepics",
     "aioca",
-    "pydantic<2.0",
+    "pydantic<2.0",      # Leave pinned until can check incompatibility
     "stomp-py",
     "aiohttp",
     "PyYAML",
-    "click<8.1.4",
-    "fastapi[all]<0.99", # Later versions use a newer openapi schema, which is incompatible with swagger see https://github.com/swagger-api/swagger-codegen/issues/10446
+    "click",
+    "fastapi[all]",
     "uvicorn",
     "requests",
     "dls-bluesky-core",  #requires ophyd-async
@@ -45,7 +45,7 @@ dev = [
     "pytest-asyncio",
     "responses",
     "ruff",
-    "sphinx-autobuild==2024.2.4", # Later versions have a clash with fastapi<0.99, remove pin when fastapi is a higher version
+    "sphinx-autobuild",
     "sphinx-copybutton",
     "sphinx-click",
     "sphinx-design",


### PR DESCRIPTION
FastAPI and its compatible version of Starlette had a header injection vulnerability, we have committed to move beyond our pinned version and resolve dependency issues in the Java code-gen client