### PR TITLE
Add super-state-machine as direct dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "requests",
     "dls-bluesky-core",  #requires ophyd-async
     "dls-dodal>=1.24.0",
+    "super-state-machine", # See GH issue 553
 ]
 dynamic = ["version"]
 license.file = "LICENSE"


### PR DESCRIPTION
This was previously available as a transitive dependency from bluesky but has now been removed (bluesky/bluesky#1708).

This is a temporary workaround to make the build work again and may be reverted if the types are made available from bluesky in future.

See #553.