### PR TITLE
Update schema test after count plan update

### DIFF
--- a/tests/service/test_rest_api.py
+++ b/tests/service/test_rest_api.py
@@ -78,7 +78,7 @@ def test_get_plan_with_device_reference(handler: Handler, client: TestClient) ->
             "    Take `n` readings from a device\n"
             "\n"
             "    Args:\n"
-            "        detectors (List[Readable]): Readable devices to read\n"
+            "        detectors (Set[Readable]): Readable devices to read\n"
             "        num (int, optional): Number of readings to take. "
             "Defaults to 1.\n"
             "        delay (Optional[Union[float, List[float]]], "
@@ -113,6 +113,7 @@ def test_get_plan_with_device_reference(handler: Handler, client: TestClient) ->
                         "items": {"type": "bluesky.protocols.Readable"},
                         "title": "Detectors",
                         "type": "array",
+                        "uniqueItems": True,
                     },
                     "metadata": {"title": "Metadata", "type": "object"},
                     "num": {"title": "Num", "type": "integer"},


### PR DESCRIPTION
The count plan was updated to take a set instead of a list which meant
the generated schema changed to include the 'uniqueItems' key.
