### PR TITLE
Fix extraEnvVars in helm chart

### DIFF
--- a/helm/blueapi/templates/deployment.yaml
+++ b/helm/blueapi/templates/deployment.yaml
@@ -92,10 +92,8 @@ spec:
             - "-c"
             - "/config/config.yaml"
             - "serve"
-          {{- with .Values.extraEnvVars }}
           env:
-            {{- tpl .Values.extraEnvVars . | nindent 10 }}
-          {{- end }}
+            {{- toYaml .Values.extraEnvVars | nindent 12 }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
Fixes #581 

`extraEnvVars` was being treated as a string in some places and a list in others. This PR makes it a list everywhere, any values files that look like this should be updated to remove the `|`:

```yaml
extraEnvVars: |
  - name: BEAMLINE
    value: i04
```