### PR TITLE
Update sonarcloud.yml with the condition for this repo instance

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -6,7 +6,9 @@ on:
       - main
   pull_request:
     types: [opened, synchronize, reopened]
+
 name: SonarCloud check
+
 jobs:
   sonarcloud:
     runs-on: ubuntu-latest
@@ -15,8 +17,11 @@ jobs:
         with:
           # Disabling shallow clone is recommended for improving relevancy of reporting
           fetch-depth: 0
+
       - name: SonarCloud Scan
-        uses: sonarsource/sonarcloud-github-action@v3.0.0 # Ex: v2.1.0, See the latest version at https://github.com/marketplace/actions/sonarcloud-scan
+        # Skip SonarCloud Scan if the pull request is from a forked repository
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+        uses: sonarsource/sonarcloud-github-action@v3.0.0
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_ORG_KEY: ${{ secrets.SONAR_ORG_KEY }}


### PR DESCRIPTION
> The sonarcloud workflow requires an auth key, so will not work with PRs from forks, which we want to support. We will therefore skip that job when the PR is from a fork.

thanks @callumforrester 