### PR TITLE
Do not create FastAPI app until config loaded

### DIFF
--- a/src/blueapi/service/openapi.py
+++ b/src/blueapi/service/openapi.py
@@ -7,12 +7,13 @@ import yaml
 from fastapi.openapi.utils import get_openapi
 from pyparsing import Any
 
-from blueapi.service.main import app
+from blueapi.service.main import get_app
 
 DOCS_SCHEMA_LOCATION = Path(__file__).parents[3] / "docs" / "reference" / "openapi.yaml"
 
 
 def generate_schema() -> Mapping[str, Any]:
+    app = get_app()
     return get_openapi(
         title=app.title,
         version=app.version,

--- a/tests/unit_tests/service/test_openapi.py
+++ b/tests/unit_tests/service/test_openapi.py
@@ -7,9 +7,13 @@ import yaml
 from blueapi.service.openapi import DOCS_SCHEMA_LOCATION, generate_schema
 
 
-@mock.patch("blueapi.service.openapi.app")
-def test_generate_schema(mock_app: Mock) -> None:
-    from blueapi.service.main import app
+@mock.patch("blueapi.service.openapi.get_app")
+def test_generate_schema(mock_get_app: Mock) -> None:
+    mock_app = mock_get_app()
+
+    from blueapi.service.main import get_app
+
+    app = get_app()
 
     title = PropertyMock(return_value="title")
     version = PropertyMock(return_value=app.version)
@@ -22,8 +26,6 @@ def test_generate_schema(mock_app: Mock) -> None:
     type(mock_app).openapi_version = openapi_version
     type(mock_app).description = description
     type(mock_app).routes = routes
-
-    # from blueapi.service.openapi import generate_schema
 
     assert generate_schema() == {
         "openapi": openapi_version(),

--- a/tests/unit_tests/service/test_rest_api.py
+++ b/tests/unit_tests/service/test_rest_api.py
@@ -25,11 +25,9 @@ from blueapi.worker.task_worker import TrackableTask
 
 @pytest.fixture
 def client() -> Iterator[TestClient]:
-    with (
-        patch("blueapi.service.interface.worker"),
-    ):
+    with patch("blueapi.service.interface.worker"):
         main.setup_runner(use_subprocess=False)
-        yield TestClient(main.app)
+        yield TestClient(main.get_app())
         main.teardown_runner()
 
 


### PR DESCRIPTION
Defers creation of the FastAPI app, which will allow configuration to be loaded first.
This will allow us to e.g. configure authentication prior to starting the app.