### PR TITLE
Extract OTEL parsing to configMap to allow consistent handling of env

### DIFF
--- a/helm/blueapi/templates/configmap.yaml
+++ b/helm/blueapi/templates/configmap.yaml
@@ -5,3 +5,16 @@ metadata:
 data:
   config.yaml: |-
     {{- toYaml .Values.worker | nindent 4 }}
+
+---
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "blueapi.fullname" . }}-otel-config
+data:
+{{ if .Values.tracing.otlp.enabled | default false }}
+  OTLP_EXPORT_ENABLED: "true"
+  OTEL_EXPORTER_OTLP_TRACES_PROTOCOL: {{ .Values.tracing.otlp.protocol | default "http/protobuff" }}
+  OTEL_EXPORTER_OTLP_ENDPOINT: {{ required "OTLP export enabled but server address not set" .Values.tracing.otlp.server.host }}:{{ .Values.tracing.otlp.server.port | default 4138 }}
+{{ end }}

--- a/helm/blueapi/templates/configmap.yaml
+++ b/helm/blueapi/templates/configmap.yaml
@@ -13,8 +13,8 @@ kind: ConfigMap
 metadata:
   name: {{ include "blueapi.fullname" . }}-otel-config
 data:
-{{ if .Values.tracing.otlp.enabled | default false }}
+{{- if .Values.tracing.otlp.enabled | default false }}
   OTLP_EXPORT_ENABLED: "true"
-  OTEL_EXPORTER_OTLP_TRACES_PROTOCOL: {{ .Values.tracing.otlp.protocol | default "http/protobuff" }}
-  OTEL_EXPORTER_OTLP_ENDPOINT: {{ required "OTLP export enabled but server address not set" .Values.tracing.otlp.server.host }}:{{ .Values.tracing.otlp.server.port | default 4138 }}
+  OTEL_EXPORTER_OTLP_TRACES_PROTOCOL: {{ .Values.tracing.otlp.protocol | default "http/protobuf" }}
+  OTEL_EXPORTER_OTLP_ENDPOINT: {{ required "OTLP export enabled but server address not set" .Values.tracing.otlp.server.host }}:{{ .Values.tracing.otlp.server.port | default 4318 }}
 {{ end }}

--- a/helm/blueapi/templates/statefulset.yaml
+++ b/helm/blueapi/templates/statefulset.yaml
@@ -97,6 +97,9 @@ spec:
             - "-c"
             - "/config/config.yaml"
             - "serve"
+          envFrom:
+            - configMapRef:
+                name: {{ include "blueapi.fullname" . }}-otel-config
           env:
             {{- toYaml .Values.extraEnvVars | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/helm/blueapi/values.yaml
+++ b/helm/blueapi/values.yaml
@@ -76,13 +76,7 @@ listener:
   resources: {}
 
 # Additional envVars to mount to the pod as a String
-extraEnvVars: |
-  - name: OTLP_EXPORT_ENABLED
-    value: {{ .Values.tracing.otlp.export_enabled }}
-  - name: OTEL_EXPORTER_OTLP_TRACES_PROTOCOL
-    value: {{ .Values.tracing.otlp.protocol }}
-  - name: OTEL_EXPORTER_OTLP_ENDPOINT
-    value: "{{ .Values.tracing.otlp.host }}:{{ .Values.tracing.otlp.port }}"
+extraEnvVars:
 # - name: RABBITMQ_PASSWORD
 #   valueFrom:
 #     secretKeyRef:
@@ -91,10 +85,11 @@ extraEnvVars: |
 
 tracing:
   otlp:
-    export_enabled: false
+    enabled: false
     protocol: http/protobuf
-    host: https://daq-services-jaeger # replace with central instance
-    port: 4318
+    server:
+      host: https://daq-services-jaeger # replace with central instance
+      port: 4318
 
 # Config for the worker goes here, will be mounted into a config file
 worker:

--- a/helm/blueapi/values.yaml
+++ b/helm/blueapi/values.yaml
@@ -76,7 +76,7 @@ listener:
   resources: {}
 
 # Additional envVars to mount to the pod as a String
-extraEnvVars:
+extraEnvVars: []
 # - name: RABBITMQ_PASSWORD
 #   valueFrom:
 #     secretKeyRef:


### PR DESCRIPTION
This handling does not require that string parsing is done on the extraEnvVars, and so resolves the need for them to be a string re: #582 