### PR TITLE
Update start_rabbitmq.sh

### DIFF
--- a/src/script/start_rabbitmq.sh
+++ b/src/script/start_rabbitmq.sh
@@ -2,7 +2,7 @@
 SCRIPT_DIR=$( cd -- "$( dirname -- "$BASH_SOURCE[0]" )" &> /dev/null && pwd )
 RABBITMQ_VERSION="rabbitmq:management"
 cmd1='run -it --rm --name rabbitmq -v '\
-$SCRIPT_DIR'/rabbitmq_setup/enabled_plugins:/etc/rabbitmq/enabled_plugins'\
+$SCRIPT_DIR'/rabbitmq_setup/enabled_plugins:/etc/rabbitmq/enabled_plugins:z'\
 ' -p 5672:5672 -p 15672:15672 -p 61613:61613 '$RABBITMQ_VERSION
 
 echo "Checking docker/podman installation"


### PR DESCRIPTION
Patch rabbit startup script for SElinux compatibility - necessary for it to run on my workstation and shouldn't hurt for anyone else - relabels permissions for the container user so that SElinux doesn't complain about access

Fixes #703