### PR TITLE
Fix pytest break on exception every time

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import asyncio
+import os
 from typing import Any, cast
 
 # Based on https://docs.pytest.org/en/latest/example/simple.html#control-skipping-of-tests-according-to-command-line-option  # noqa: E501
@@ -41,16 +42,19 @@ def exporter() -> JsonObjectSpanExporter:
     return exporter
 
 
-@pytest.hookimpl(tryfirst=True)
-def pytest_exception_interact(call: pytest.CallInfo[Any]):
-    if call.excinfo is not None:
-        raise call.excinfo.value
-    else:
-        raise RuntimeError(
-            f"{call} has no exception data, an unknown error has occurred"
-        )
+# Prevent pytest from catching exceptions when debugging in vscode so that break on
+# exception works correctly (see: https://github.com/pytest-dev/pytest/issues/7409)
+if os.getenv("PYTEST_RAISE", "0") == "1":
 
+    @pytest.hookimpl(tryfirst=True)
+    def pytest_exception_interact(call: pytest.CallInfo[Any]):
+        if call.excinfo is not None:
+            raise call.excinfo.value
+        else:
+            raise RuntimeError(
+                f"{call} has no exception data, an unknown error has occurred"
+            )
 
-@pytest.hookimpl(tryfirst=True)
-def pytest_internalerror(excinfo: pytest.ExceptionInfo[Any]):
-    raise excinfo.value
+    @pytest.hookimpl(tryfirst=True)
+    def pytest_internalerror(excinfo: pytest.ExceptionInfo[Any]):
+        raise excinfo.value


### PR DESCRIPTION
Fixes #736 
Fixes #737 

Due to a small discrepency when updating the copeier template pytest was always running in a mode where it would immediately exit after the first failure. This change reinstates the missing line of code in `conftest.py`.