### PR TITLE
Fix auth token saving

### DIFF
--- a/src/blueapi/service/authentication.py
+++ b/src/blueapi/service/authentication.py
@@ -18,7 +18,7 @@ from requests.auth import AuthBase
 from blueapi.config import OIDCConfig
 from blueapi.service.model import Cache
 
-BLUEAPI_CACHE_LOCATION = "~/.cache/"
+DEFAULT_CAHCE_DIR = "~/.cache/"
 SCOPES = "openid offline_access"
 
 
@@ -60,7 +60,7 @@ class SessionCacheManager(CacheManager):
         """
         Return the default cache file path.
         """
-        cache_path = os.environ.get("XDG_CACHE_HOME", BLUEAPI_CACHE_LOCATION)
+        cache_path = os.environ.get("XDG_CACHE_HOME", DEFAULT_CAHCE_DIR)
         return Path(cache_path).expanduser() / "blueapi_cache"
 
 

--- a/src/blueapi/service/authentication.py
+++ b/src/blueapi/service/authentication.py
@@ -33,7 +33,9 @@ class CacheManager(ABC):
 
 class SessionCacheManager(CacheManager):
     def __init__(self, token_path: Path | None) -> None:
-        self._token_path: Path = token_path if token_path else self._get_xdg_cache_dir()
+        self._token_path: Path = (
+            token_path if token_path else self._get_xdg_cache_path()
+        )
 
     @cached_property
     def _file_path(self) -> str:
@@ -54,14 +56,16 @@ class SessionCacheManager(CacheManager):
     def delete_cache(self) -> None:
         Path(self._file_path).unlink(missing_ok=True)
 
-    def _get_xdg_cache_dir(self) -> Path:
+    def _get_xdg_cache_path(self) -> Path:
         """
-        Return the XDG cache directory.
+        Return the XDG cache file path.
         """
-        cache_dir = os.environ.get("XDG_CACHE_HOME")
-        if not cache_dir:
-            cache_dir = os.path.expanduser(BLUEAPI_CACHE_LOCATION)
-        return Path(cache_dir)
+        cache = os.environ.get("XDG_CACHE_HOME")
+        if not cache:
+            cache = os.path.expanduser(BLUEAPI_CACHE_LOCATION)
+        elif os.path.isdir(cache):
+            cache = Path(cache) / "blueapi_cache"
+        return Path(cache)
 
 
 class SessionManager:

--- a/src/blueapi/service/authentication.py
+++ b/src/blueapi/service/authentication.py
@@ -60,12 +60,12 @@ class SessionCacheManager(CacheManager):
         """
         Return the XDG cache file path.
         """
-        cache = os.environ.get("XDG_CACHE_HOME")
-        if not cache:
-            cache = os.path.expanduser(BLUEAPI_CACHE_LOCATION)
-        elif os.path.isdir(cache):
-            cache = Path(cache) / "blueapi_cache"
-        return Path(cache)
+        cache_path = os.environ.get("XDG_CACHE_HOME")
+        if not cache_path:
+            cache_path = os.path.expanduser(BLUEAPI_CACHE_LOCATION)
+        elif os.path.isdir(cache_path):
+            cache_path = Path(cache_path) / "blueapi_cache"
+        return Path(cache_path)
 
 
 class SessionManager:

--- a/src/blueapi/service/authentication.py
+++ b/src/blueapi/service/authentication.py
@@ -18,7 +18,7 @@ from requests.auth import AuthBase
 from blueapi.config import OIDCConfig
 from blueapi.service.model import Cache
 
-BLUEAPI_CACHE_LOCATION = "~/.cache/blueapi_cache"
+BLUEAPI_CACHE_LOCATION = "~/.cache/"
 SCOPES = "openid offline_access"
 
 
@@ -34,7 +34,7 @@ class CacheManager(ABC):
 class SessionCacheManager(CacheManager):
     def __init__(self, token_path: Path | None) -> None:
         self._token_path: Path = (
-            token_path if token_path else self._get_xdg_cache_path()
+            token_path if token_path else self._default_token_cache_path()
         )
 
     @cached_property
@@ -56,16 +56,12 @@ class SessionCacheManager(CacheManager):
     def delete_cache(self) -> None:
         Path(self._file_path).unlink(missing_ok=True)
 
-    def _get_xdg_cache_path(self) -> Path:
+    def _default_token_cache_path(self) -> Path:
         """
-        Return the XDG cache file path.
+        Return the default cache file path.
         """
-        cache_path = os.environ.get("XDG_CACHE_HOME")
-        if not cache_path:
-            cache_path = os.path.expanduser(BLUEAPI_CACHE_LOCATION)
-        elif os.path.isdir(cache_path):
-            cache_path = Path(cache_path) / "blueapi_cache"
-        return Path(cache_path)
+        cache_path = os.environ.get("XDG_CACHE_HOME", BLUEAPI_CACHE_LOCATION)
+        return Path(cache_path).expanduser() / "blueapi_cache"
 
 
 class SessionManager:

--- a/tests/unit_tests/service/test_authentication.py
+++ b/tests/unit_tests/service/test_authentication.py
@@ -10,10 +10,7 @@ from starlette.status import HTTP_403_FORBIDDEN
 
 from blueapi.config import OIDCConfig
 from blueapi.service import main
-from blueapi.service.authentication import (
-    SessionCacheManager,
-    SessionManager,
-)
+from blueapi.service.authentication import SessionCacheManager, SessionManager
 
 
 @pytest.fixture
@@ -132,3 +129,12 @@ def test_processes_valid_token(
 ):
     inner = main.verify_access_token(oidc_config)
     inner(access_token=valid_token_with_jwt["access_token"])
+
+
+def test_session_cache_manager_returns_writable_file_path(tmp_path):
+    with patch("os.environ.get") as xdg_directory:
+        xdg_directory.return_value = tmp_path
+        cache = SessionCacheManager(token_path=None)
+        with open(cache._file_path, "xb") as token_file:
+            assert token_file.writable()
+        assert cache._file_path == f"{tmp_path}/blueapi_cache"

--- a/tests/unit_tests/service/test_authentication.py
+++ b/tests/unit_tests/service/test_authentication.py
@@ -132,9 +132,8 @@ def test_processes_valid_token(
 
 
 def test_session_cache_manager_returns_writable_file_path(tmp_path):
-    with patch("os.environ.get") as xdg_directory:
-        xdg_directory.return_value = tmp_path
-        cache = SessionCacheManager(token_path=None)
-        with open(cache._file_path, "xb") as token_file:
-            assert token_file.writable()
-        assert cache._file_path == f"{tmp_path}/blueapi_cache"
+    os.environ["XDG_CACHE_HOME"] = str(tmp_path)
+    cache = SessionCacheManager(token_path=None)
+    Path(cache._file_path).touch()
+    assert os.path.isfile(cache._file_path)
+    assert cache._file_path == f"{tmp_path}/blueapi_cache"


### PR DESCRIPTION
resolve a bug in file saving 

The environment variable `XDG_CONFIG_HOME` contains a directory not a file path. So adding a file name in front of directory path to get a writable location