### PR TITLE
Auth test speedup

### DIFF
--- a/tests/unit_tests/service/test_authentication.py
+++ b/tests/unit_tests/service/test_authentication.py
@@ -95,7 +95,7 @@ def test_poll_for_token(
     assert token == valid_token
 
 
-@patch("time.sleep")
+@patch("blueapi.service.authentication.time.sleep", return_value=None)
 def test_poll_for_token_timeout(
     mock_sleep,
     oidc_well_known: dict[str, Any],
@@ -111,7 +111,7 @@ def test_poll_for_token_timeout(
         status=HTTP_403_FORBIDDEN,
     )
     with pytest.raises(TimeoutError), mock_authn_server:
-        session_manager.poll_for_token(device_code, 0.01, 0.1)
+        session_manager.poll_for_token(device_code, 0.01, 0.01)
 
 
 def test_server_raises_exception_for_invalid_token(


### PR DESCRIPTION
closes #758
The execution time for <code>test_poll_for_token_timeout</code> was reduced successfully:
```
pytest tests/unit_tests/service/test_authentication.py::test_poll_for_token_timeout  
# Before: 2s
# After: 0.25s  
```
Overall Suite Performance (Main vs. Branch)

Environment | Main | Optimized Branch | Delta
-- | -- | -- | --
Python 3.10 | 13.39s (295 passed, 1 skipped) | 11.36s (295 passed, 1 skipped) | -2.03s (-15.2%)
Python 3.11 | 14.99s (295 passed, 1 skipped) | 13.17s (295 passed, 1 skipped) | -1.82s (-12.1%)
Python 3.12 | 21.16s (295 passed, 1 skipped) | 18.17s (295 passed, 1 skipped) | -2.99s (-14.1%)
Dev Environment | 15.73s (296 passed) | 13.08s (296 passed) | -2.65s (-16.8%)

The results from the main branch are from this [action](https://github.com/DiamondLightSource/blueapi/actions/runs/12351731671/job/34467302396#step:7:381) 