### PR TITLE
Use an external directory for container python cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 COPY --from=build /venv/ /venv/
 ENV PATH=/venv/bin:$PATH
+ENV PYTHONPYCACHEPREFIX=/tmp/blueapi_pycache
 
 RUN mkdir -p /.cache/pip; chmod -R 777 /venv /.cache/pip
 


### PR DESCRIPTION
With this set, the pyc files are created in a mirror directory instead
of the source tree. When running in a shared directory (as is the case
for the scratch area used by bluapi), this prevents files being created
with permissions that prevent other users removing them.

See python docs at
https://docs.python.org/3/using/cmdline.html#envvar-PYTHONPYCACHEPREFIX

Fixes #812

### Instructions to reviewer on how to test:
1. Deploy and run on p46 with new scratch area
2. Check that there are no `__pycache__` directories created in the scratch area

### Checks for reviewer
- [X] Would the PR title make sense to a user on a set of release notes
