### PR TITLE
Pass visit id when starting task

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,4 +9,7 @@
     "[python]": {
         "editor.defaultFormatter": "charliermarsh.ruff",
     },
+    "cSpell.words": [
+        "blueapi"
+    ],
 }

--- a/docs/reference/openapi.yaml
+++ b/docs/reference/openapi.yaml
@@ -252,7 +252,7 @@ components:
       type: object
 info:
   title: BlueAPI Control
-  version: 0.0.5
+  version: 0.0.6
 openapi: 3.1.0
 paths:
   /devices:
@@ -527,6 +527,13 @@ paths:
 
         This will return an error response if the worker is not idle.'
       operationId: set_active_task_worker_task_put
+      parameters:
+      - in: query
+        name: instrument_session
+        required: true
+        schema:
+          title: Instrument Session
+          type: string
       requestBody:
         content:
           application/json:

--- a/src/blueapi/cli/cli.py
+++ b/src/blueapi/cli/cli.py
@@ -208,6 +208,7 @@ def listen_to_events(obj: dict) -> None:
 
 @controller.command(name="run")
 @click.argument("name", type=str)
+@click.argument("instrument_session", type=str)
 @click.argument("parameters", type=str, required=False)
 @click.option(
     "-t",
@@ -219,7 +220,11 @@ def listen_to_events(obj: dict) -> None:
 @check_connection
 @click.pass_obj
 def run_plan(
-    obj: dict, name: str, parameters: str | None, timeout: float | None
+    obj: dict,
+    name: str,
+    instrument_session: str,
+    parameters: str | None,
+    timeout: float | None,
 ) -> None:
     """Run a plan with parameters"""
     client: BlueapiClient = obj["client"]
@@ -239,7 +244,7 @@ def run_plan(
 
     try:
         task = Task(name=name, params=parsed_params)
-        resp = client.run_task(task, on_event=on_event)
+        resp = client.run_task(task, instrument_session, on_event=on_event)
     except ValidationError as e:
         pprint(f"failed to validate the task parameters, {task_id}, error: {e}")
         return

--- a/src/blueapi/client/client.py
+++ b/src/blueapi/client/client.py
@@ -193,6 +193,7 @@ class BlueapiClient:
     def run_task(
         self,
         task: Task,
+        instrument_session: str,
         on_event: OnAnyEvent | None = None,
         timeout: float | None = None,
     ) -> WorkerEvent:
@@ -249,11 +250,13 @@ class BlueapiClient:
 
         with self._events:
             self._events.subscribe_to_all_events(inner_on_event)
-            self.start_task(WorkerTask(task_id=task_id))
+            self.start_task(WorkerTask(task_id=task_id), instrument_session)
             return complete.result(timeout=timeout)
 
     @start_as_current_span(TRACER, "task")
-    def create_and_start_task(self, task: Task) -> TaskResponse:
+    def create_and_start_task(
+        self, task: Task, instrument_session: str
+    ) -> TaskResponse:
         """
         Create a new task and instruct the worker to start it
         immediately.
@@ -266,7 +269,9 @@ class BlueapiClient:
         """
 
         response = self.create_task(task)
-        worker_response = self.start_task(WorkerTask(task_id=response.task_id))
+        worker_response = self.start_task(
+            WorkerTask(task_id=response.task_id), instrument_session
+        )
         if worker_response.task_id == response.task_id:
             return response
         else:
@@ -304,7 +309,7 @@ class BlueapiClient:
         return self._rest.clear_task(task_id)
 
     @start_as_current_span(TRACER, "task")
-    def start_task(self, task: WorkerTask) -> WorkerTask:
+    def start_task(self, task: WorkerTask, instrument_session: str) -> WorkerTask:
         """
         Instruct the worker to start a stored task immediately
 
@@ -315,7 +320,7 @@ class BlueapiClient:
             WorkerTask: Acknowledgement of request
         """
 
-        return self._rest.update_worker_task(task)
+        return self._rest.update_worker_task(task, instrument_session)
 
     @start_as_current_span(TRACER, "reason")
     def abort(self, reason: str | None = None) -> WorkerState:

--- a/src/blueapi/client/rest.py
+++ b/src/blueapi/client/rest.py
@@ -104,11 +104,14 @@ class BlueapiRestClient:
             f"/tasks/{task_id}", TaskResponse, method="DELETE"
         )
 
-    def update_worker_task(self, task: WorkerTask) -> WorkerTask:
+    def update_worker_task(
+        self, task: WorkerTask, instrument_session: str
+    ) -> WorkerTask:
         return self._request_and_deserialize(
             "/worker/task",
             WorkerTask,
             method="PUT",
+            params={"instrument_session": instrument_session},
             data=task.model_dump(),
         )
 
@@ -141,6 +144,7 @@ class BlueapiRestClient:
         suffix: str,
         target_type: type[T],
         data: Mapping[str, Any] | None = None,
+        params: Mapping[str, Any] | None = None,
         method="GET",
         get_exception: Callable[[requests.Response], Exception | None] = _exception,
     ) -> T:
@@ -148,18 +152,14 @@ class BlueapiRestClient:
         # Get the trace context to propagate to the REST API
         carr = get_context_propagator()
 
-        if data:
-            response = requests.request(
-                method,
-                url,
-                json=data,
-                headers=carr,
-                auth=JWTAuth(self._session_manager),
-            )
-        else:
-            response = requests.request(
-                method, url, headers=carr, auth=JWTAuth(self._session_manager)
-            )
+        response = requests.request(
+            method,
+            url,
+            json=data,
+            params=params,
+            headers=carr,
+            auth=JWTAuth(self._session_manager),
+        )
         exception = get_exception(response)
         if exception is not None:
             raise exception

--- a/src/blueapi/service/interface.py
+++ b/src/blueapi/service/interface.py
@@ -144,10 +144,10 @@ def clear_task(task_id: str) -> str:
     return worker().clear_task(task_id)
 
 
-def begin_task(task: WorkerTask) -> WorkerTask:
+def begin_task(task: WorkerTask, instrument_session: str) -> WorkerTask:
     """Trigger a task. Will fail if the worker is busy"""
     if task.task_id is not None:
-        worker().begin_task(task.task_id)
+        worker().begin_task(task.task_id, instrument_session)
     return task
 
 

--- a/src/blueapi/service/main.py
+++ b/src/blueapi/service/main.py
@@ -45,7 +45,7 @@ from .model import (
 )
 from .runner import WorkerDispatcher
 
-REST_API_VERSION = "0.0.5"
+REST_API_VERSION = "0.0.6"
 
 RUNNER: WorkerDispatcher | None = None
 

--- a/src/blueapi/service/main.py
+++ b/src/blueapi/service/main.py
@@ -112,7 +112,7 @@ def get_app(config: ApplicationConfig):
 
 
 def verify_access_token(config: OIDCConfig):
-    jwkclient = jwt.PyJWKClient(config.jwks_uri)
+    jwk_client = jwt.PyJWKClient(config.jwks_uri)
     oauth_scheme = OAuth2AuthorizationCodeBearer(
         authorizationUrl=config.authorization_endpoint,
         tokenUrl=config.token_endpoint,
@@ -120,7 +120,7 @@ def verify_access_token(config: OIDCConfig):
     )
 
     def inner(access_token: str = Depends(oauth_scheme)):
-        signing_key = jwkclient.get_signing_key_from_jwt(access_token)
+        signing_key = jwk_client.get_signing_key_from_jwt(access_token)
         jwt.decode(
             access_token,
             signing_key.key,

--- a/src/blueapi/service/main.py
+++ b/src/blueapi/service/main.py
@@ -304,6 +304,7 @@ def get_tasks(
 @start_as_current_span(TRACER, "task.task_id")
 def set_active_task(
     task: WorkerTask,
+    instrument_session: str,
     runner: WorkerDispatcher = Depends(_runner),
 ) -> WorkerTask:
     """Set a task to active status, the worker should begin it as soon as possible.
@@ -313,7 +314,7 @@ def set_active_task(
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT, detail="Worker already active"
         )
-    runner.run(interface.begin_task, task)
+    runner.run(interface.begin_task, task, instrument_session)
     return task
 
 

--- a/src/blueapi/worker/task_worker.py
+++ b/src/blueapi/worker/task_worker.py
@@ -194,10 +194,10 @@ class TaskWorker:
         return current
 
     @start_as_current_span(TRACER, "task_id")
-    def begin_task(self, task_id: str) -> None:
+    def begin_task(self, task_id: str, instrument_session: str) -> None:
         task = self._tasks.get(task_id)
         if task is not None:
-            self._submit_trackable_task(task)
+            self._submit_trackable_task(task, instrument_session)
         else:
             raise KeyError(f"No pending task with ID {task_id}")
 
@@ -217,8 +217,11 @@ class TaskWorker:
         "trackable_task.task_id",
         "trackable_task.task.name",
         "trackable_task.task.params",
+        "instrument_session",
     )
-    def _submit_trackable_task(self, trackable_task: TrackableTask) -> None:
+    def _submit_trackable_task(
+        self, trackable_task: TrackableTask, instrument_session: str
+    ) -> None:
         if self.state is not WorkerState.IDLE:
             raise WorkerBusyError(f"Worker is in state {self.state}")
 
@@ -235,7 +238,6 @@ class TaskWorker:
         sub = self.worker_events.subscribe(mark_task_as_started)
         try:
             self._current_task_otel_context = get_current()
-            sub = self.worker_events.subscribe(mark_task_as_started)
             """ Cache the current trace context as the one for this task id """
             self._task_channel.put_nowait(trackable_task)
             task_started.wait(timeout=5.0)

--- a/tests/unit_tests/client/test_client.py
+++ b/tests/unit_tests/client/test_client.py
@@ -111,7 +111,7 @@ def test_get_plan(client: BlueapiClient):
     assert client.get_plan("foo") == PLAN
 
 
-def test_get_nonexistant_plan(
+def test_get_nonexistent_plan(
     client: BlueapiClient,
     mock_rest: Mock,
 ):
@@ -128,7 +128,7 @@ def test_get_device(client: BlueapiClient):
     assert client.get_device("foo") == DEVICE
 
 
-def test_get_nonexistant_device(
+def test_get_nonexistent_device(
     client: BlueapiClient,
     mock_rest: Mock,
 ):
@@ -202,7 +202,7 @@ def test_start_task(
     mock_rest.update_worker_task.assert_called_once_with(WorkerTask(task_id="bar"))
 
 
-def test_start_nonexistant_task(
+def test_start_nonexistent_task(
     client: BlueapiClient,
     mock_rest: Mock,
 ):
@@ -642,5 +642,5 @@ def test_cannot_run_task_span_ok(
         RuntimeError,
         match="Cannot run plans without Stomp configuration to track progress",
     ):
-        with asserting_span_exporter(exporter, "grun_task"):
+        with asserting_span_exporter(exporter, "run_task"):
             client.run_task(Task(name="foo"))

--- a/tests/unit_tests/service/test_interface.py
+++ b/tests/unit_tests/service/test_interface.py
@@ -39,6 +39,11 @@ def ensure_worker_stopped():
     interface.teardown()
 
 
+@pytest.fixture
+def instrument_session() -> str:
+    return "cm12345-1"
+
+
 def my_plan() -> MsgGenerator:
     """My plan does cool stuff."""
     yield from {}
@@ -180,18 +185,18 @@ def test_clear_task(context_mock: MagicMock):
 
 
 @patch("blueapi.service.interface.TaskWorker.begin_task")
-def test_begin_task(worker_mock: MagicMock):
+def test_begin_task(worker_mock: MagicMock, instrument_session: str):
     uuid_value = "350043fd-597e-41a7-9a92-5d5478232cf7"
     task = WorkerTask(task_id=uuid_value)
-    returned_task = interface.begin_task(task)
+    returned_task = interface.begin_task(task, instrument_session)
     assert task == returned_task
-    worker_mock.assert_called_once_with(uuid_value)
+    worker_mock.assert_called_once_with(uuid_value, instrument_session)
 
 
 @patch("blueapi.service.interface.TaskWorker.begin_task")
-def test_begin_task_no_task_id(worker_mock: MagicMock):
+def test_begin_task_no_task_id(worker_mock: MagicMock, instrument_session: str):
     task = WorkerTask(task_id=None)
-    returned_task = interface.begin_task(task)
+    returned_task = interface.begin_task(task, instrument_session)
     assert task == returned_task
     worker_mock.assert_not_called()
 

--- a/tests/unit_tests/service/test_rest_api.py
+++ b/tests/unit_tests/service/test_rest_api.py
@@ -64,6 +64,11 @@ def client_with_auth(
         main.teardown_runner()
 
 
+@pytest.fixture
+def instrument_session() -> str:
+    return "cm12345-1"
+
+
 def test_get_plans(mock_runner: Mock, client: TestClient) -> None:
     class MyModel(BaseModel):
         id: str
@@ -211,16 +216,22 @@ def test_create_task_validation_error(mock_runner: Mock, client: TestClient) -> 
     }
 
 
-def test_put_plan_begins_task(client: TestClient) -> None:
+def test_put_plan_begins_task(client: TestClient, instrument_session: str) -> None:
     task_id = "04cd9aa6-b902-414b-ae4b-49ea4200e957"
 
-    resp = client.put("/worker/task", json={"task_id": task_id})
+    resp = client.put(
+        "/worker/task",
+        json={"task_id": task_id},
+        params={"instrument_session": instrument_session},
+    )
 
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json() == {"task_id": task_id}
 
 
-def test_put_plan_fails_if_not_idle(mock_runner: Mock, client: TestClient) -> None:
+def test_put_plan_fails_if_not_idle(
+    mock_runner: Mock, client: TestClient, instrument_session: str
+) -> None:
     task_id_current = "260f7de3-b608-4cdc-a66c-257e95809792"
     task_id_new = "07e98d68-21b5-4ad7-ac34-08b2cb992d42"
 
@@ -229,7 +240,11 @@ def test_put_plan_fails_if_not_idle(mock_runner: Mock, client: TestClient) -> No
         task=None, task_id=task_id_current, is_complete=False
     )
 
-    resp = client.put("/worker/task", json={"task_id": task_id_new})
+    resp = client.put(
+        "/worker/task",
+        json={"task_id": task_id_new},
+        params={"instrument_session": instrument_session},
+    )
 
     assert resp.status_code == status.HTTP_409_CONFLICT
     assert resp.json() == {"detail": "Worker already active"}
@@ -312,18 +327,22 @@ def test_delete_submitted_task(mock_runner: Mock, client: TestClient) -> None:
     assert response.json() == {"task_id": f"{task_id}"}
 
 
-def test_set_active_task(client: TestClient) -> None:
+def test_set_active_task(client: TestClient, instrument_session: str) -> None:
     task_id = str(uuid.uuid4())
     task = WorkerTask(task_id=task_id)
 
-    response = client.put("/worker/task", json=task.model_dump())
+    response = client.put(
+        "/worker/task",
+        json=task.model_dump(),
+        params={"instrument_session": instrument_session},
+    )
 
     assert response.status_code == status.HTTP_200_OK
     assert response.json() == {"task_id": f"{task_id}"}
 
 
 def test_set_active_task_active_task_complete(
-    mock_runner: Mock, client: TestClient
+    mock_runner: Mock, client: TestClient, instrument_session: str
 ) -> None:
     task_id = str(uuid.uuid4())
     task = WorkerTask(task_id=task_id)
@@ -335,14 +354,18 @@ def test_set_active_task_active_task_complete(
         is_pending=False,
     )
 
-    response = client.put("/worker/task", json=task.model_dump())
+    response = client.put(
+        "/worker/task",
+        json=task.model_dump(),
+        params={"instrument_session": instrument_session},
+    )
 
     assert response.status_code == status.HTTP_200_OK
     assert response.json() == {"task_id": f"{task_id}"}
 
 
 def test_set_active_task_worker_already_running(
-    mock_runner: Mock, client: TestClient
+    mock_runner: Mock, client: TestClient, instrument_session: str
 ) -> None:
     task_id = str(uuid.uuid4())
     task = WorkerTask(task_id=task_id)
@@ -354,7 +377,11 @@ def test_set_active_task_worker_already_running(
         is_pending=False,
     )
 
-    response = client.put("/worker/task", json=task.model_dump())
+    response = client.put(
+        "/worker/task",
+        json=task.model_dump(),
+        params={"instrument_session": instrument_session},
+    )
 
     assert response.status_code == status.HTTP_409_CONFLICT
     assert response.json() == {"detail": "Worker already active"}

--- a/tests/unit_tests/worker/test_task_worker.py
+++ b/tests/unit_tests/worker/test_task_worker.py
@@ -88,6 +88,11 @@ def worker(inert_worker: TaskWorker) -> Iterable[TaskWorker]:
     inert_worker.stop()
 
 
+@pytest.fixture
+def instrument_session() -> str:
+    return "cm12345-1"
+
+
 def test_stop_doesnt_hang(inert_worker: TaskWorker) -> None:
     inert_worker.start()
     inert_worker.stop()
@@ -204,6 +209,7 @@ def test_clear_nonexistent_task(worker: TaskWorker) -> None:
 
 def test_does_not_allow_simultaneous_running_tasks(
     worker: TaskWorker,
+    instrument_session: str,
     fake_device: FakeDevice,
 ) -> None:
     task_ids = [
@@ -212,26 +218,30 @@ def test_does_not_allow_simultaneous_running_tasks(
     ]
     with pytest.raises(WorkerBusyError):
         for task_id in task_ids:
-            worker.begin_task(task_id)
+            worker.begin_task(task_id, instrument_session)
     fake_device.event.set()
 
 
-def test_begin_task_blocks_until_current_task_set(worker: TaskWorker) -> None:
+def test_begin_task_blocks_until_current_task_set(
+    worker: TaskWorker, instrument_session: str
+):
     task_id = worker.submit_task(_SIMPLE_TASK)
     assert worker.get_active_task() is None
-    worker.begin_task(task_id)
+    worker.begin_task(task_id, instrument_session)
     active_task = worker.get_active_task()
     assert active_task is not None
     assert active_task.task == _SIMPLE_TASK
 
 
-def test_plan_failure_recorded_in_active_task(worker: TaskWorker) -> None:
+def test_plan_failure_recorded_in_active_task(
+    worker: TaskWorker, instrument_session: str
+):
     task_id = worker.submit_task(_FAILING_TASK)
     events_future: Future[list[WorkerEvent]] = take_events(
         worker.worker_events,
         lambda event: event.task_status is not None and event.task_status.task_failed,
     )
-    worker.begin_task(task_id)
+    worker.begin_task(task_id, instrument_session)
     events = events_future.result(timeout=5.0)
     assert events[-1].task_status is not None
     assert events[-1].task_status.task_failed
@@ -243,12 +253,14 @@ def test_plan_failure_recorded_in_active_task(worker: TaskWorker) -> None:
 
 
 @pytest.mark.parametrize("num_runs", [0, 1, 2])
-def test_produces_worker_events(worker: TaskWorker, num_runs: int) -> None:
+def test_produces_worker_events(
+    worker: TaskWorker, num_runs: int, instrument_session: str
+):
     task_ids = [worker.submit_task(_SIMPLE_TASK) for _ in range(num_runs)]
     event_sequences = [_sleep_events(task_id) for task_id in task_ids]
 
     for task_id, events in zip(task_ids, event_sequences, strict=False):
-        assert_run_produces_worker_events(events, worker, task_id)
+        assert_run_produces_worker_events(events, worker, task_id, instrument_session)
 
 
 def _sleep_events(task_id: str) -> list[WorkerEvent]:
@@ -280,7 +292,9 @@ def _sleep_events(task_id: str) -> list[WorkerEvent]:
     ]
 
 
-def test_no_additional_progress_events_after_complete(worker: TaskWorker):
+def test_no_additional_progress_events_after_complete(
+    worker: TaskWorker, instrument_session: str
+):
     """
     See https://github.com/bluesky/ophyd/issues/1115
     """
@@ -290,7 +304,7 @@ def test_no_additional_progress_events_after_complete(worker: TaskWorker):
 
     task: Task = Task(name="move", params={"moves": {"additional_status_device": 5.0}})
     task_id = worker.submit_task(task)
-    begin_task_and_wait_until_complete(worker, task_id)
+    begin_task_and_wait_until_complete(worker, task_id, instrument_session)
 
     # Extract all the display_name fields from the events
     list_of_dict_keys = [pe.statuses.values() for pe in progress_events]
@@ -301,14 +315,16 @@ def test_no_additional_progress_events_after_complete(worker: TaskWorker):
 
 
 @patch("queue.Queue.put_nowait")
-def test_full_queue_raises_WorkerBusyError(put_nowait: MagicMock, worker: TaskWorker):
-    def raise_full(item):
+def test_full_queue_raises_WorkerBusyError(
+    put_nowait: MagicMock, worker: TaskWorker, instrument_session: str
+):
+    def raise_full(_):
         raise Full()
 
     put_nowait.side_effect = raise_full
     task = worker.submit_task(_SIMPLE_TASK)
     with pytest.raises(WorkerBusyError):
-        worker.begin_task(task)
+        worker.begin_task(task, instrument_session)
 
 
 #
@@ -320,13 +336,18 @@ def assert_run_produces_worker_events(
     expected_events: list[WorkerEvent],
     worker: TaskWorker,
     task_id: str,
+    instrument_session: str,
 ) -> None:
-    assert begin_task_and_wait_until_complete(worker, task_id) == expected_events
+    assert (
+        begin_task_and_wait_until_complete(worker, task_id, instrument_session)
+        == expected_events
+    )
 
 
 def begin_task_and_wait_until_complete(
     worker: TaskWorker,
     task_id: str,
+    instrument_session: str,
     timeout: float = 5.0,
 ) -> list[WorkerEvent]:
     events: Future[list[WorkerEvent]] = take_events(
@@ -334,7 +355,7 @@ def begin_task_and_wait_until_complete(
         lambda event: event.is_complete(),
     )
 
-    worker.begin_task(task_id)
+    worker.begin_task(task_id, instrument_session)
     return events.result(timeout=timeout)
 
 
@@ -353,7 +374,7 @@ def path_provider(tmp_path: Path):
 
 
 def test_worker_and_data_events_produce_in_order(
-    worker: TaskWorker, path_provider
+    worker: TaskWorker, instrument_session: str
 ) -> None:
     assert_running_count_plan_produces_ordered_worker_and_data_events(
         [
@@ -387,12 +408,14 @@ def test_worker_and_data_events_produce_in_order(
             ),
         ],
         worker,
+        instrument_session,
     )
 
 
 def assert_running_count_plan_produces_ordered_worker_and_data_events(
     expected_events: list[WorkerEvent | DataEvent],
     worker: TaskWorker,
+    instrument_session: str,
     task: Task | None = None,
     timeout: float = 5.0,
 ) -> None:
@@ -411,7 +434,7 @@ def assert_running_count_plan_produces_ordered_worker_and_data_events(
     )
 
     task_id = worker.submit_task(task)
-    worker.begin_task(task_id)
+    worker.begin_task(task_id, instrument_session)
     results = events.result(timeout=timeout)
 
     for actual, expected in itertools.zip_longest(results, expected_events):
@@ -570,11 +593,11 @@ def test_clear_task_span_ok(
 
 
 def test_begin_task_span_ok(
-    exporter: JsonObjectSpanExporter, worker: TaskWorker
+    exporter: JsonObjectSpanExporter, worker: TaskWorker, instrument_session: str
 ) -> None:
     task_id = worker.submit_task(_SIMPLE_TASK)
     with asserting_span_exporter(exporter, "begin_task", "task_id"):
-        worker.begin_task(task_id)
+        worker.begin_task(task_id, instrument_session)
 
 
 def test_injected_devices_are_found(


### PR DESCRIPTION
Fixes #793 

This does all of the grunt work necessary to get to a point where the instrument_session can be checked with the authentication information passed with the request to be checked to ensure the user is permitted to make their request.

Additional tasks coming off of this one and possible to be merged into this PR before it is merged in turn into main:

- Allow user to select a visit when they log in
- Cache the above visit if it is selected and pass it with every request to prevent having to be explicit
- Checking authentication information and instrument_session to ensure user is authorized to make request
- Using the instrument_session as part of the call to the PathProvider (see #828 et al.)