### PR TITLE
Bluesky moveable update

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,9 +13,8 @@ classifiers = [
 ]
 description = "Lightweight bluesky-as-a-service wrapper application. Also usable as a library."
 dependencies = [
-    "bluesky>=1.13",
+    "bluesky>=1.13.1",
     "ophyd",
-    "nslsii",
     "pyepics",
     "aioca",
     "pydantic>=2.0",

--- a/src/blueapi/config.py
+++ b/src/blueapi/config.py
@@ -60,6 +60,8 @@ class EnvironmentConfig(BlueapiBaseModel):
         ),
         Source(kind=SourceKind.PLAN_FUNCTIONS, module="blueapi.startup.example_plans"),
         Source(kind=SourceKind.PLAN_FUNCTIONS, module="dodal.plans"),
+        # This plan is not JSON serializable specifically bluesky.Moveable
+        # https://github.com/DiamondLightSource/dodal/blob/a3b1b8c540cea6a4180471818c258e53577856af/src/dodal/plan_stubs/wrapped.py#L18
         Source(kind=SourceKind.PLAN_FUNCTIONS, module="dodal.plan_stubs.wrapped"),
     ]
     events: WorkerEventConfig = Field(default_factory=WorkerEventConfig)

--- a/tests/unit_tests/worker/devices.py
+++ b/tests/unit_tests/worker/devices.py
@@ -1,8 +1,12 @@
 # Devices to use for worker tests
 
+from typing import TypeVar
+
 from bluesky.protocols import Movable
 from ophyd import Device, DeviceStatus
 from ophyd.status import Status
+
+T = TypeVar("T")
 
 
 class AdditionalUpdateStatus(DeviceStatus):
@@ -39,7 +43,7 @@ class AdditionalUpdateStatus(DeviceStatus):
             )
 
 
-class AdditionalStatusDevice(Device, Movable):
+class AdditionalStatusDevice(Device, Movable[float]):
     def set(self, value: float) -> Status:  # type: ignore
         status = AdditionalUpdateStatus(self)
         return status  # type: ignore


### PR DESCRIPTION
 Removed `nslsii` from dev-requirements as currently it is not being used in the code base 

There is some issues in the `bluesky==1.13.1` with the change of `bluesky.Moveable` protocol

#838 