### PR TITLE
Add SkipJsonSchema annotations to optional fields

### DIFF
--- a/docs/reference/openapi.yaml
+++ b/docs/reference/openapi.yaml
@@ -340,7 +340,7 @@ components:
       type: object
 info:
   title: BlueAPI Control
-  version: 0.0.9
+  version: 0.0.10
 openapi: 3.1.0
 paths:
   /config/oidc:

--- a/docs/reference/openapi.yaml
+++ b/docs/reference/openapi.yaml
@@ -44,12 +44,10 @@ components:
           title: Environment Id
           type: string
         error_message:
-          anyOf:
-          - minLength: 1
-            type: string
-          - type: 'null'
           description: If present - error loading context
+          minLength: 1
           title: Error Message
+          type: string
         initialized:
           description: blueapi context initialized
           title: Initialized
@@ -98,21 +96,17 @@ components:
       description: Representation of a plan
       properties:
         description:
-          anyOf:
-          - type: string
-          - type: 'null'
           description: Docstring of the plan
           title: Description
+          type: string
         name:
           description: Name of the plan
           title: Name
           type: string
         schema:
-          anyOf:
-          - type: object
-          - type: 'null'
           description: Schema of the plan's parameters
           title: Schema
+          type: object
       required:
       - name
       title: PlanModel
@@ -182,11 +176,9 @@ components:
         new_state:
           $ref: '#/components/schemas/WorkerState'
         reason:
-          anyOf:
-          - type: string
-          - type: 'null'
           description: The reason for the current run to be aborted
           title: Reason
+          type: string
       required:
       - new_state
       title: StateChangeRequest
@@ -251,10 +243,8 @@ components:
           title: Is Pending
           type: boolean
         request_id:
-          anyOf:
-          - type: string
-          - type: 'null'
           title: Request Id
+          type: string
         task:
           title: Task
         task_id:
@@ -306,11 +296,9 @@ components:
       description: Worker's active task ID, can be None
       properties:
         task_id:
-          anyOf:
-          - type: string
-          - type: 'null'
           description: The ID of the current task, None if the worker is idle
           title: Task Id
+          type: string
       required:
       - task_id
       title: WorkerTask
@@ -468,10 +456,8 @@ paths:
         name: task_status
         required: false
         schema:
-          anyOf:
-          - type: string
-          - type: 'null'
           title: Task Status
+          type: string
       responses:
         '200':
           content:
@@ -603,10 +589,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/WorkerState'
           description: Successful Response
-          detail: Transition requested
         '400':
           description: Bad Request
-          detail: Transition not allowed
         '422':
           content:
             application/json:
@@ -646,7 +630,6 @@ paths:
           description: Successful Response
         '409':
           description: Conflict
-          worker: already active
         '422':
           content:
             application/json:

--- a/src/blueapi/service/main.py
+++ b/src/blueapi/service/main.py
@@ -24,6 +24,7 @@ from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
 from opentelemetry.propagate import get_global_textmap
 from opentelemetry.trace import get_tracer_provider
 from pydantic import ValidationError
+from pydantic.json_schema import SkipJsonSchema
 from starlette.responses import JSONResponse
 from super_state_machine.errors import TransitionError
 
@@ -275,7 +276,7 @@ def validate_task_status(v: str) -> TaskStatusEnum:
 @router.get("/tasks", response_model=TasksListResponse, status_code=status.HTTP_200_OK)
 @start_as_current_span(TRACER)
 def get_tasks(
-    task_status: str | None = None,
+    task_status: str | SkipJsonSchema[None] = None,
     runner: WorkerDispatcher = Depends(_runner),
 ) -> TasksListResponse:
     """
@@ -302,7 +303,7 @@ def get_tasks(
 @router.put(
     "/worker/task",
     response_model=WorkerTask,
-    responses={status.HTTP_409_CONFLICT: {"worker": "already active"}},
+    responses={status.HTTP_409_CONFLICT: {}},
 )
 @start_as_current_span(TRACER, "task.task_id")
 def set_active_task(
@@ -379,8 +380,8 @@ _ALLOWED_TRANSITIONS: dict[WorkerState, set[WorkerState]] = {
     "/worker/state",
     status_code=status.HTTP_202_ACCEPTED,
     responses={
-        status.HTTP_400_BAD_REQUEST: {"detail": "Transition not allowed"},
-        status.HTTP_202_ACCEPTED: {"detail": "Transition requested"},
+        status.HTTP_400_BAD_REQUEST: {},
+        status.HTTP_202_ACCEPTED: {},
     },
 )
 @start_as_current_span(TRACER, "state_change_request.new_state")

--- a/src/blueapi/service/main.py
+++ b/src/blueapi/service/main.py
@@ -49,7 +49,7 @@ from .model import (
 from .runner import WorkerDispatcher
 
 #: API version to publish in OpenAPI schema
-REST_API_VERSION = "0.0.7"
+REST_API_VERSION = "0.0.8"
 
 RUNNER: WorkerDispatcher | None = None
 

--- a/src/blueapi/service/model.py
+++ b/src/blueapi/service/model.py
@@ -1,10 +1,11 @@
 import uuid
 from collections.abc import Iterable
 from enum import Enum
-from typing import Any
+from typing import Annotated, Any
 
 from bluesky.protocols import HasName
 from pydantic import Field
+from pydantic.json_schema import SkipJsonSchema
 
 from blueapi.config import OIDCConfig
 from blueapi.core import BLUESKY_PROTOCOLS, Device, Plan
@@ -79,8 +80,10 @@ class PlanModel(BlueapiBaseModel):
     """
 
     name: str = Field(description="Name of the plan")
-    description: str | None = Field(description="Docstring of the plan", default=None)
-    parameter_schema: dict[str, Any] | None = Field(
+    description: str | SkipJsonSchema[None] = Field(
+        description="Docstring of the plan", default=None
+    )
+    parameter_schema: dict[str, Any] | SkipJsonSchema[None] = Field(
         description="Schema of the plan's parameters",
         alias="schema",
         default_factory=dict,
@@ -124,7 +127,7 @@ class WorkerTask(BlueapiBaseModel):
     Worker's active task ID, can be None
     """
 
-    task_id: str | None = Field(
+    task_id: str | SkipJsonSchema[None] = Field(
         description="The ID of the current task, None if the worker is idle"
     )
 
@@ -147,7 +150,7 @@ class StateChangeRequest(BlueapiBaseModel):
         description="Should worker defer Pausing until the next checkpoint",
         default=False,
     )
-    reason: str | None = Field(
+    reason: str | SkipJsonSchema[None] = Field(
         description="The reason for the current run to be aborted",
         default=None,
     )
@@ -163,10 +166,9 @@ class EnvironmentResponse(BlueapiBaseModel):
         "differentiate between a new environment and old that has been torn down"
     )
     initialized: bool = Field(description="blueapi context initialized")
-    error_message: str | None = Field(
+    error_message: Annotated[str, Field(min_length=1)] | SkipJsonSchema[None] = Field(
         default=None,
         description="If present - error loading context",
-        min_length=1,
     )
 
 

--- a/src/blueapi/worker/task_worker.py
+++ b/src/blueapi/worker/task_worker.py
@@ -19,6 +19,7 @@ from opentelemetry.baggage import get_baggage
 from opentelemetry.context import Context, get_current
 from opentelemetry.trace import SpanKind
 from pydantic import Field
+from pydantic.json_schema import SkipJsonSchema
 from super_state_machine.errors import TransitionError
 
 from blueapi.core import (
@@ -62,7 +63,7 @@ class TrackableTask(BlueapiBaseModel, Generic[T]):
 
     task_id: str
     task: T
-    request_id: str | None = None
+    request_id: str | SkipJsonSchema[None] = None
     is_complete: bool = False
     is_pending: bool = True
     errors: list[str] = Field(default_factory=list)


### PR DESCRIPTION
Prevents 'null' being included as a possible type in the generated
schema which interferes with the generated Java client.

The 'detail' and 'worker' entries on response types were flagged as an
error in the schema when the client was generated.
