### PR TITLE
Prevent Enum classes being treated as Bluesky Protocols

### DIFF
--- a/docs/reference/openapi.yaml
+++ b/docs/reference/openapi.yaml
@@ -269,7 +269,7 @@ components:
       type: object
 info:
   title: BlueAPI Control
-  version: 0.0.5
+  version: 0.0.6
 openapi: 3.1.0
 paths:
   /devices:

--- a/src/blueapi/core/bluesky_types.py
+++ b/src/blueapi/core/bluesky_types.py
@@ -13,9 +13,6 @@ from bluesky.protocols import (
     Checkable,
     Configurable,
     Flyable,
-    HasHints,
-    HasName,
-    HasParent,
     Movable,
     Pausable,
     Readable,
@@ -40,9 +37,6 @@ PlanWrapper = Callable[[MsgGenerator], MsgGenerator]
 Device = (
     Checkable
     | Flyable
-    | HasHints
-    | HasName
-    | HasParent
     | Movable
     | Pausable
     | Readable

--- a/src/blueapi/core/context.py
+++ b/src/blueapi/core/context.py
@@ -66,7 +66,7 @@ def qualified_name(target: type) -> str:
     return f"{module_name}{name}"
 
 
-def is_bluesky_type(typ: type):
+def is_bluesky_type(typ: type) -> bool:
     return typ in BLUESKY_PROTOCOLS or isinstance(typ, BLUESKY_PROTOCOLS)
 
 
@@ -322,13 +322,12 @@ class BlueskyContext:
         Returns:
             A Type that can be deserialised by Pydantic
         """
-        origin = get_origin(typ)
-        if is_bluesky_type(typ) or (origin is not None and is_bluesky_type(origin)):
+        root = get_origin(typ)
+        if is_bluesky_type(typ) or (root is not None and is_bluesky_type(root)):
             return self._reference(typ)
         args = get_args(typ)
         if args:
             new_types = tuple(self._convert_type(i) for i in args)
-            root = get_origin(typ)
             if root == UnionType:
                 root = Union
             return root[new_types] if root else typ  # type: ignore

--- a/src/blueapi/core/context.py
+++ b/src/blueapi/core/context.py
@@ -6,6 +6,7 @@ from inspect import Parameter, signature
 from types import ModuleType, UnionType
 from typing import Any, Generic, TypeVar, Union, get_args, get_origin, get_type_hints
 
+from bluesky.protocols import HasName
 from bluesky.run_engine import RunEngine
 from dodal.utils import make_all_devices
 from ophyd_async.core import NotConnected
@@ -25,7 +26,6 @@ from blueapi.utils import (
 from .bluesky_types import (
     BLUESKY_PROTOCOLS,
     Device,
-    HasName,
     Plan,
     PlanGenerator,
     is_bluesky_compatible_device,

--- a/src/blueapi/service/main.py
+++ b/src/blueapi/service/main.py
@@ -45,7 +45,7 @@ from .model import (
 )
 from .runner import WorkerDispatcher
 
-REST_API_VERSION = "0.0.5"
+REST_API_VERSION = "0.0.6"
 
 RUNNER: WorkerDispatcher | None = None
 

--- a/src/blueapi/service/model.py
+++ b/src/blueapi/service/model.py
@@ -1,12 +1,13 @@
 import uuid
 from collections.abc import Iterable
-from typing import Any, get_args
+from typing import Any
 
 from bluesky.protocols import HasName
 from pydantic import Field
 
 from blueapi.config import OIDCConfig
 from blueapi.core import BLUESKY_PROTOCOLS, Device, Plan
+from blueapi.core.context import generic_bounds
 from blueapi.utils import BlueapiBaseModel
 from blueapi.worker import WorkerState
 from blueapi.worker.task_worker import TaskWorker, TrackableTask
@@ -35,21 +36,15 @@ class DeviceModel(BlueapiBaseModel):
     @classmethod
     def from_device(cls, device: Device) -> "DeviceModel":
         name = device.name if isinstance(device, HasName) else _UNKNOWN_NAME
-        return cls(name=name, protocols=list(_protocol_names(device)))
+        return cls(name=name, protocols=list(_protocol_info(device)))
 
 
-def generic_bounds(device, protocol) -> list[str]:
-    for base in getattr(device, "__orig_bases__", ()):
-        if getattr(base, "__name__", None) == protocol.__name__:
-            return [arg.__name__ for arg in get_args(base)]
-    return []
-
-
-def _protocol_names(device: Device) -> Iterable[ProtocolInfo]:
+def _protocol_info(device: Device) -> Iterable[ProtocolInfo]:
     for protocol in BLUESKY_PROTOCOLS:
         if isinstance(device, protocol):
             yield ProtocolInfo(
-                name=protocol.__name__, types=generic_bounds(device, protocol)
+                name=protocol.__name__,
+                types=[arg.__name__ for arg in generic_bounds(device, protocol)],
             )
 
 

--- a/tests/system_tests/devices.json
+++ b/tests/system_tests/devices.json
@@ -4,10 +4,6 @@
             "name": "data_class_motor",
             "protocols": [
                 {
-                    "name": "HasName",
-                    "types": []
-                },
-                {
                     "name": "Movable",
                     "types": [
                         "DataClassType"
@@ -19,10 +15,6 @@
             "name": "dynamic_motor",
             "protocols": [
                 {
-                    "name": "HasName",
-                    "types": []
-                },
-                {
                     "name": "Movable",
                     "types": [
                         "MotorPositions"
@@ -33,10 +25,6 @@
         {
             "name": "movable_motor",
             "protocols": [
-                {
-                    "name": "HasName",
-                    "types": []
-                },
                 {
                     "name": "Movable",
                     "types": [
@@ -50,18 +38,6 @@
             "protocols": [
                 {
                     "name": "Checkable",
-                    "types": []
-                },
-                {
-                    "name": "HasHints",
-                    "types": []
-                },
-                {
-                    "name": "HasName",
-                    "types": []
-                },
-                {
-                    "name": "HasParent",
                     "types": []
                 },
                 {
@@ -106,18 +82,6 @@
                     "types": []
                 },
                 {
-                    "name": "HasHints",
-                    "types": []
-                },
-                {
-                    "name": "HasName",
-                    "types": []
-                },
-                {
-                    "name": "HasParent",
-                    "types": []
-                },
-                {
                     "name": "Movable",
                     "types": []
                 },
@@ -156,18 +120,6 @@
             "protocols": [
                 {
                     "name": "Checkable",
-                    "types": []
-                },
-                {
-                    "name": "HasHints",
-                    "types": []
-                },
-                {
-                    "name": "HasName",
-                    "types": []
-                },
-                {
-                    "name": "HasParent",
                     "types": []
                 },
                 {
@@ -212,18 +164,6 @@
                     "types": []
                 },
                 {
-                    "name": "HasHints",
-                    "types": []
-                },
-                {
-                    "name": "HasName",
-                    "types": []
-                },
-                {
-                    "name": "HasParent",
-                    "types": []
-                },
-                {
                     "name": "Movable",
                     "types": []
                 },
@@ -262,18 +202,6 @@
             "protocols": [
                 {
                     "name": "Checkable",
-                    "types": []
-                },
-                {
-                    "name": "HasHints",
-                    "types": []
-                },
-                {
-                    "name": "HasName",
-                    "types": []
-                },
-                {
-                    "name": "HasParent",
                     "types": []
                 },
                 {
@@ -318,18 +246,6 @@
                     "types": []
                 },
                 {
-                    "name": "HasHints",
-                    "types": []
-                },
-                {
-                    "name": "HasName",
-                    "types": []
-                },
-                {
-                    "name": "HasParent",
-                    "types": []
-                },
-                {
                     "name": "Movable",
                     "types": []
                 },
@@ -371,18 +287,6 @@
                     "types": []
                 },
                 {
-                    "name": "HasHints",
-                    "types": []
-                },
-                {
-                    "name": "HasName",
-                    "types": []
-                },
-                {
-                    "name": "HasParent",
-                    "types": []
-                },
-                {
                     "name": "Pausable",
                     "types": []
                 },
@@ -420,18 +324,6 @@
                     "types": []
                 },
                 {
-                    "name": "HasHints",
-                    "types": []
-                },
-                {
-                    "name": "HasName",
-                    "types": []
-                },
-                {
-                    "name": "HasParent",
-                    "types": []
-                },
-                {
                     "name": "Pausable",
                     "types": []
                 },
@@ -466,18 +358,6 @@
             "protocols": [
                 {
                     "name": "Checkable",
-                    "types": []
-                },
-                {
-                    "name": "HasHints",
-                    "types": []
-                },
-                {
-                    "name": "HasName",
-                    "types": []
-                },
-                {
-                    "name": "HasParent",
                     "types": []
                 },
                 {

--- a/tests/unit_tests/core/fake_device_module.py
+++ b/tests/unit_tests/core/fake_device_module.py
@@ -72,6 +72,12 @@ def _mock_with_name(name: str) -> MagicMock:
     # mock.name must return str, cannot MagicMock(name=name)
     mock = MagicMock()
     mock.name = name
+
+    def stop(self, success: bool = True) -> None:
+        pass
+
+    mock.stop = stop
+
     return mock
 
 

--- a/tests/unit_tests/core/test_context.py
+++ b/tests/unit_tests/core/test_context.py
@@ -5,7 +5,14 @@ from typing import Generic, TypeVar, Union
 from unittest.mock import patch
 
 import pytest
-from bluesky.protocols import Descriptor, Movable, Readable, Reading, SyncOrAsync
+from bluesky.protocols import (
+    Descriptor,
+    Movable,
+    Readable,
+    Reading,
+    Stoppable,
+    SyncOrAsync,
+)
 from bluesky.utils import MsgGenerator
 from dodal.common import PlanGenerator, inject
 from ophyd.sim import SynAxis, SynGauss
@@ -421,26 +428,29 @@ def test_generic_default_device_reference(empty_context: BlueskyContext) -> None
     assert spec["mov"][1].default_factory == DefaultFactory("demo")
 
 
-class Named:
-    """Concrete implementation of a Bluesky protocol (HasName)"""
+class ConcreteStoppable(Stoppable):
+    """Concrete implementation of a Bluesky protocol"""
 
     @property
     def name(self) -> str:
         return "Concrete"
 
+    def stop(self, success: bool = True) -> None:
+        pass
+
 
 def test_concrete_type_conversion(empty_context: BlueskyContext) -> None:
-    hasname_ref = empty_context._reference(Named)
-    assert empty_context._convert_type(Named) == hasname_ref
+    stoppable_ref = empty_context._reference(ConcreteStoppable)
+    assert empty_context._convert_type(ConcreteStoppable) == stoppable_ref
 
 
 def test_concrete_method_annotation(empty_context: BlueskyContext) -> None:
-    hasname_ref = empty_context._reference(Named)
+    stoppable_ref = empty_context._reference(ConcreteStoppable)
 
-    def demo(named: Named) -> None: ...
+    def demo(named: ConcreteStoppable) -> None: ...
 
     spec = empty_context._type_spec_for_function(demo)
-    assert spec["named"][0] is hasname_ref
+    assert spec["named"][0] is stoppable_ref
     assert spec["named"][1].default_factory is None
 
 

--- a/tests/unit_tests/service/test_interface.py
+++ b/tests/unit_tests/service/test_interface.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from unittest.mock import ANY, MagicMock, Mock, patch
 
 import pytest
+from bluesky.protocols import Stoppable
 from bluesky.utils import MsgGenerator
 from bluesky_stomp.messaging import StompClient
 from ophyd.sim import SynAxis
@@ -104,8 +105,11 @@ def test_get_plan(context_mock: MagicMock):
 
 
 @dataclass
-class MyDevice:
+class MyDevice(Stoppable):
     name: str
+
+    def stop(self, success: bool = True) -> None:
+        pass
 
 
 @patch("blueapi.service.interface.context")
@@ -116,14 +120,11 @@ def test_get_devices(context_mock: MagicMock):
     context_mock.return_value = context
 
     assert interface.get_devices() == [
-        DeviceModel(name="my_device", protocols=[ProtocolInfo(name="HasName")]),
+        DeviceModel(name="my_device", protocols=[ProtocolInfo(name="Stoppable")]),
         DeviceModel(
             name="my_axis",
             protocols=[
                 ProtocolInfo(name="Checkable"),
-                ProtocolInfo(name="HasHints"),
-                ProtocolInfo(name="HasName"),
-                ProtocolInfo(name="HasParent"),
                 ProtocolInfo(name="Movable"),
                 ProtocolInfo(name="Pausable"),
                 ProtocolInfo(name="Readable"),
@@ -144,7 +145,7 @@ def test_get_device(context_mock: MagicMock):
     context_mock.return_value = context
 
     assert interface.get_device("my_device") == DeviceModel(
-        name="my_device", protocols=[ProtocolInfo(name="HasName")]
+        name="my_device", protocols=[ProtocolInfo(name="Stoppable")]
     )
 
     with pytest.raises(KeyError):

--- a/tests/unit_tests/service/test_rest_api.py
+++ b/tests/unit_tests/service/test_rest_api.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, Mock, patch
 
 import jwt
 import pytest
+from bluesky.protocols import Stoppable
 from fastapi import status
 from fastapi.testclient import TestClient
 from pydantic import BaseModel, ValidationError
@@ -62,6 +63,14 @@ def client_with_auth(
         main.setup_runner(runner=mock_runner)
         yield TestClient(main.get_app(ApplicationConfig(oidc=oidc_config)))
         main.teardown_runner()
+
+
+@dataclass
+class MinimalDevice(Stoppable):
+    name: str
+
+    def stop(self, success: bool = True):
+        pass
 
 
 def test_get_plans(mock_runner: Mock, client: TestClient) -> None:
@@ -122,11 +131,7 @@ def test_get_non_existent_plan_by_name(mock_runner: Mock, client: TestClient) ->
 
 
 def test_get_devices(mock_runner: Mock, client: TestClient) -> None:
-    @dataclass
-    class MyDevice:
-        name: str
-
-    device = MyDevice("my-device")
+    device = MinimalDevice("my-device")
     mock_runner.run.return_value = [DeviceModel.from_device(device)]
 
     response = client.get("/devices")
@@ -136,18 +141,14 @@ def test_get_devices(mock_runner: Mock, client: TestClient) -> None:
         "devices": [
             {
                 "name": "my-device",
-                "protocols": [{"name": "HasName", "types": []}],
+                "protocols": [{"name": "Stoppable", "types": []}],
             }
         ]
     }
 
 
 def test_get_device_by_name(mock_runner: Mock, client: TestClient) -> None:
-    @dataclass
-    class MyDevice:
-        name: str
-
-    device = MyDevice("my-device")
+    device = MinimalDevice("my-device")
 
     mock_runner.run.return_value = DeviceModel.from_device(device)
     response = client.get("/devices/my-device")
@@ -156,7 +157,7 @@ def test_get_device_by_name(mock_runner: Mock, client: TestClient) -> None:
     assert response.status_code == status.HTTP_200_OK
     assert response.json() == {
         "name": "my-device",
-        "protocols": [{"name": "HasName", "types": []}],
+        "protocols": [{"name": "Stoppable", "types": []}],
     }
 
 

--- a/tests/unit_tests/test_cli.py
+++ b/tests/unit_tests/test_cli.py
@@ -158,7 +158,7 @@ def test_get_devices(runner: CliRunner):
 
     plans = runner.invoke(main, ["controller", "devices"])
     assert response.call_count == 1
-    assert plans.output == "my-device\n    HasName, Movable['ComplexType']\n"
+    assert plans.output == "my-device\n    Movable['ComplexType']\n"
 
 
 def test_invalid_config_path_handling(runner: CliRunner):
@@ -413,7 +413,7 @@ def test_device_output_formatting():
 
     compact = dedent("""\
                 my-device
-                    HasName, Movable['ComplexType']
+                    Movable['ComplexType']
                 """)
 
     _assert_matching_formatting(OutputFormat.COMPACT, devices, compact)
@@ -423,10 +423,6 @@ def test_device_output_formatting():
                   {
                     "name": "my-device",
                     "protocols": [
-                      {
-                        "name": "HasName",
-                        "types": []
-                      },
                       {
                         "name": "Movable",
                         "types": [
@@ -442,7 +438,6 @@ def test_device_output_formatting():
 
     full = dedent("""\
             my-device
-                HasName
                 Movable['ComplexType']
             """)
     _assert_matching_formatting(OutputFormat.FULL, devices, full)


### PR DESCRIPTION
Enum defines a property for `name` and `value`- meaning that according to ducks, any enum class extends `HasName`. Now that we are checking the origin of types, we have started catching this when trying to import plans that take enums as a parameter and possibly even just on devices that have enums as a type arg (e.g. a Movable[ShutterDemand]).

This change makes HasName, HasParent and HasHints on their own no longer sufficient to define that  a class is a Device class.

This was making blueapi try and treat Enum classes as Device classes, and so constructing References which extend them- extending an Enum class is not allowed.