### PR TITLE
Always construct auth route

### DIFF
--- a/docs/reference/openapi.yaml
+++ b/docs/reference/openapi.yaml
@@ -355,9 +355,6 @@ paths:
         '204':
           description: No Authentication configured
       summary: Get Oidc Config
-      tags:
-      - auth
-      - meta
   /devices:
     get:
       description: Retrieve information about all available devices.
@@ -495,8 +492,6 @@ paths:
                 $ref: '#/components/schemas/HTTPValidationError'
           description: Validation Error
       summary: Get Python Environment
-      tags:
-      - meta
   /tasks:
     get:
       description: 'Retrieve tasks based on their status.

--- a/docs/reference/openapi.yaml
+++ b/docs/reference/openapi.yaml
@@ -68,6 +68,27 @@ components:
           type: array
       title: HTTPValidationError
       type: object
+    OIDCConfig:
+      additionalProperties: false
+      properties:
+        client_audience:
+          default: blueapi
+          description: Client Audience(s)
+          title: Client Audience
+          type: string
+        client_id:
+          description: Client ID
+          title: Client Id
+          type: string
+        well_known_url:
+          description: URL to fetch OIDC config from the provider
+          title: Well Known Url
+          type: string
+      required:
+      - well_known_url
+      - client_id
+      title: OIDCConfig
+      type: object
     PackageInfo:
       additionalProperties: false
       properties:
@@ -317,9 +338,26 @@ components:
       type: object
 info:
   title: BlueAPI Control
-  version: 0.0.7
+  version: 0.0.8
 openapi: 3.1.0
 paths:
+  /config/oidc:
+    get:
+      description: Retrieve the OpenID Connect (OIDC) configuration for the server.
+      operationId: get_oidc_config_config_oidc_get
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OIDCConfig'
+          description: Successful Response
+        '204':
+          description: No Authentication configured
+      summary: Get Oidc Config
+      tags:
+      - auth
+      - meta
   /devices:
     get:
       description: Retrieve information about all available devices.
@@ -457,6 +495,8 @@ paths:
                 $ref: '#/components/schemas/HTTPValidationError'
           description: Validation Error
       summary: Get Python Environment
+      tags:
+      - meta
   /tasks:
     get:
       description: 'Retrieve tasks based on their status.

--- a/src/blueapi/cli/cli.py
+++ b/src/blueapi/cli/cli.py
@@ -389,6 +389,9 @@ def login(obj: dict) -> None:
     except Exception:
         client = BlueapiClient.from_config(config)
         oidc_config = client.get_oidc_config()
+        if oidc_config is None:
+            print("Server is not configured to use auth")
+            return
         auth = SessionManager(
             oidc_config, cache_manager=SessionCacheManager(config.auth_token_path)
         )

--- a/src/blueapi/cli/cli.py
+++ b/src/blueapi/cli/cli.py
@@ -390,7 +390,7 @@ def login(obj: dict) -> None:
         client = BlueapiClient.from_config(config)
         oidc_config = client.get_oidc_config()
         if oidc_config is None:
-            print("Server is not configured to use auth")
+            print("Server is not configured to use authentication!")
             return
         auth = SessionManager(
             oidc_config, cache_manager=SessionCacheManager(config.auth_token_path)

--- a/src/blueapi/client/client.py
+++ b/src/blueapi/client/client.py
@@ -430,7 +430,7 @@ class BlueapiClient:
         )
 
     @start_as_current_span(TRACER)
-    def get_oidc_config(self) -> OIDCConfig:
+    def get_oidc_config(self) -> OIDCConfig | None:
         """
         Get oidc config from the server
 

--- a/src/blueapi/client/rest.py
+++ b/src/blueapi/client/rest.py
@@ -1,8 +1,8 @@
 from collections.abc import Callable, Mapping
+from json import JSONDecodeError
 from typing import Any, Literal, TypeVar
 
 import requests
-from fastapi.exceptions import ResponseValidationError
 from observability_utils.tracing import (
     get_context_propagator,
     get_tracer,
@@ -138,7 +138,9 @@ class BlueapiRestClient:
     def get_oidc_config(self) -> OIDCConfig | None:
         try:
             return self._request_and_deserialize("/config/oidc", OIDCConfig)
-        except ResponseValidationError:
+        except JSONDecodeError:
+            # Server returned no body and status code <400
+            # Must be status code 204 (No Content): server is not using authentication
             return None
 
     def get_python_environment(

--- a/src/blueapi/service/main.py
+++ b/src/blueapi/service/main.py
@@ -177,7 +177,6 @@ async def delete_environment(
 
 @open_router.get(
     "/config/oidc",
-    tags=["auth", "meta"],
     response_model=OIDCConfig,
     responses={
         status.HTTP_204_NO_CONTENT: {"description": "No Authentication configured"}
@@ -444,9 +443,7 @@ def set_state(
     return runner.run(interface.get_worker_state)
 
 
-@secure_router.get(
-    "/python_environment", tags=["meta"], response_model=PythonEnvironmentResponse
-)
+@secure_router.get("/python_environment", response_model=PythonEnvironmentResponse)
 @start_as_current_span(TRACER)
 def get_python_environment(
     runner: WorkerDispatcher = Depends(_runner),

--- a/src/blueapi/service/main.py
+++ b/src/blueapi/service/main.py
@@ -48,7 +48,7 @@ from .model import (
 from .runner import WorkerDispatcher
 
 #: API version to publish in OpenAPI schema
-REST_API_VERSION = "0.0.7"
+REST_API_VERSION = "0.0.8"
 
 RUNNER: WorkerDispatcher | None = None
 
@@ -91,8 +91,8 @@ def lifespan(config: ApplicationConfig):
     return inner
 
 
-router = APIRouter()
-auth_router = APIRouter()
+secure_router = APIRouter()
+open_router = APIRouter()
 
 
 def get_app(config: ApplicationConfig):
@@ -104,9 +104,9 @@ def get_app(config: ApplicationConfig):
     )
     dependencies = []
     if config.oidc:
-        dependencies = [Depends(verify_access_token(config.oidc))]
-        app.include_router(auth_router)
-    app.include_router(router, dependencies=dependencies)
+        dependencies.append(Depends(verify_access_token(config.oidc)))
+    app.include_router(open_router)
+    app.include_router(secure_router, dependencies=dependencies)
     app.add_exception_handler(KeyError, on_key_error_404)
     app.add_exception_handler(jwt.PyJWTError, on_token_error_401)
     app.middleware("http")(add_api_version_header)
@@ -154,7 +154,7 @@ async def on_token_error_401(_: Request, __: Exception):
     )
 
 
-@router.get("/environment", response_model=EnvironmentResponse)
+@secure_router.get("/environment", response_model=EnvironmentResponse)
 @start_as_current_span(TRACER, "runner")
 def get_environment(
     runner: WorkerDispatcher = Depends(_runner),
@@ -163,7 +163,7 @@ def get_environment(
     return runner.state
 
 
-@router.delete("/environment", response_model=EnvironmentResponse)
+@secure_router.delete("/environment", response_model=EnvironmentResponse)
 async def delete_environment(
     background_tasks: BackgroundTasks,
     runner: WorkerDispatcher = Depends(_runner),
@@ -175,14 +175,24 @@ async def delete_environment(
     return EnvironmentResponse(environment_id=environment_id, initialized=False)
 
 
-@auth_router.get("/config/oidc", tags=["auth"], response_model=OIDCConfig)
+@open_router.get(
+    "/config/oidc",
+    tags=["auth", "meta"],
+    response_model=OIDCConfig,
+    responses={
+        status.HTTP_204_NO_CONTENT: {"description": "No Authentication configured"}
+    },
+)
 @start_as_current_span(TRACER)
-def get_oidc_config(runner: WorkerDispatcher = Depends(_runner)) -> OIDCConfig | None:
+def get_oidc_config(runner: WorkerDispatcher = Depends(_runner)) -> OIDCConfig:
     """Retrieve the OpenID Connect (OIDC) configuration for the server."""
-    return runner.run(interface.get_oidc_config)
+    config = runner.run(interface.get_oidc_config)
+    if config is None:
+        raise HTTPException(status_code=status.HTTP_204_NO_CONTENT)
+    return config
 
 
-@router.get("/plans", response_model=PlanResponse)
+@secure_router.get("/plans", response_model=PlanResponse)
 @start_as_current_span(TRACER)
 def get_plans(runner: WorkerDispatcher = Depends(_runner)):
     """Retrieve information about all available plans."""
@@ -190,7 +200,7 @@ def get_plans(runner: WorkerDispatcher = Depends(_runner)):
     return PlanResponse(plans=plans)
 
 
-@router.get(
+@secure_router.get(
     "/plans/{name}",
     response_model=PlanModel,
 )
@@ -200,7 +210,7 @@ def get_plan_by_name(name: str, runner: WorkerDispatcher = Depends(_runner)):
     return runner.run(interface.get_plan, name)
 
 
-@router.get("/devices", response_model=DeviceResponse)
+@secure_router.get("/devices", response_model=DeviceResponse)
 @start_as_current_span(TRACER)
 def get_devices(runner: WorkerDispatcher = Depends(_runner)):
     """Retrieve information about all available devices."""
@@ -208,7 +218,7 @@ def get_devices(runner: WorkerDispatcher = Depends(_runner)):
     return DeviceResponse(devices=devices)
 
 
-@router.get(
+@secure_router.get(
     "/devices/{name}",
     response_model=DeviceModel,
 )
@@ -221,7 +231,7 @@ def get_device_by_name(name: str, runner: WorkerDispatcher = Depends(_runner)):
 example_task = Task(name="count", params={"detectors": ["x"]})
 
 
-@router.post(
+@secure_router.post(
     "/tasks",
     response_model=TaskResponse,
     status_code=status.HTTP_201_CREATED,
@@ -255,7 +265,7 @@ def submit_task(
         ) from e
 
 
-@router.delete("/tasks/{task_id}", status_code=status.HTTP_200_OK)
+@secure_router.delete("/tasks/{task_id}", status_code=status.HTTP_200_OK)
 @start_as_current_span(TRACER, "task_id")
 def delete_submitted_task(
     task_id: str,
@@ -272,7 +282,9 @@ def validate_task_status(v: str) -> TaskStatusEnum:
     return TaskStatusEnum(v_upper)
 
 
-@router.get("/tasks", response_model=TasksListResponse, status_code=status.HTTP_200_OK)
+@secure_router.get(
+    "/tasks", response_model=TasksListResponse, status_code=status.HTTP_200_OK
+)
 @start_as_current_span(TRACER)
 def get_tasks(
     task_status: str | None = None,
@@ -299,7 +311,7 @@ def get_tasks(
     return TasksListResponse(tasks=tasks)
 
 
-@router.put(
+@secure_router.put(
     "/worker/task",
     response_model=WorkerTask,
     responses={status.HTTP_409_CONFLICT: {"worker": "already active"}},
@@ -329,7 +341,7 @@ def set_active_task(
     return task
 
 
-@router.get(
+@secure_router.get(
     "/tasks/{task_id}",
     response_model=TrackableTask,
 )
@@ -345,7 +357,7 @@ def get_task(
     return task
 
 
-@router.get("/worker/task")
+@secure_router.get("/worker/task")
 @start_as_current_span(TRACER)
 def get_active_task(runner: WorkerDispatcher = Depends(_runner)) -> WorkerTask:
     active = runner.run(interface.get_active_task)
@@ -353,7 +365,7 @@ def get_active_task(runner: WorkerDispatcher = Depends(_runner)) -> WorkerTask:
     return WorkerTask(task_id=task_id)
 
 
-@router.get("/worker/state")
+@secure_router.get("/worker/state")
 @start_as_current_span(TRACER)
 def get_state(runner: WorkerDispatcher = Depends(_runner)) -> WorkerState:
     """Get the State of the Worker"""
@@ -375,7 +387,7 @@ _ALLOWED_TRANSITIONS: dict[WorkerState, set[WorkerState]] = {
 }
 
 
-@router.put(
+@secure_router.put(
     "/worker/state",
     status_code=status.HTTP_202_ACCEPTED,
     responses={
@@ -432,7 +444,9 @@ def set_state(
     return runner.run(interface.get_worker_state)
 
 
-@router.get("/python_environment", response_model=PythonEnvironmentResponse)
+@secure_router.get(
+    "/python_environment", tags=["meta"], response_model=PythonEnvironmentResponse
+)
 @start_as_current_span(TRACER)
 def get_python_environment(
     runner: WorkerDispatcher = Depends(_runner),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,7 @@ import responses
 import yaml
 from bluesky._vendor.super_state_machine.errors import TransitionError
 from bluesky.run_engine import RunEngine
+from fastapi import status
 from jwcrypto.jwk import JWK
 from observability_utils.tracing import JsonObjectSpanExporter, setup_tracing
 from opentelemetry.sdk.trace import TracerProvider
@@ -316,6 +317,16 @@ def mock_authn_server(
     requests_mock.get(oidc_well_known["end_session_endpoint"], json="")
 
     with mock_jwks_fetch, requests_mock:
+        yield requests_mock
+
+
+@pytest.fixture
+def mock_unauthenticated_server():
+    requests_mock = responses.RequestsMock(assert_all_requests_are_fired=False)
+    requests_mock.get(
+        "http://localhost:8000/config/oidc", status=status.HTTP_204_NO_CONTENT
+    )
+    with requests_mock:
         yield requests_mock
 
 

--- a/tests/unit_tests/service/test_rest_api.py
+++ b/tests/unit_tests/service/test_rest_api.py
@@ -585,10 +585,13 @@ def test_get_without_authentication(mock_runner: Mock, client: TestClient) -> No
     assert response.json() == {"detail": "Not authenticated"}
 
 
-def test_oidc_config_not_found_when_auth_is_disabled(client: TestClient):
+def test_oidc_config_not_found_when_auth_is_disabled(
+    mock_runner: Mock, client: TestClient
+):
+    mock_runner.run.return_value = None
     response = client.get("/config/oidc")
-    assert response.status_code == status.HTTP_404_NOT_FOUND
-    assert response.json() == {"detail": "Not Found"}
+    assert response.status_code == status.HTTP_204_NO_CONTENT
+    assert response.text == ""
 
 
 def test_get_oidc_config(

--- a/tests/unit_tests/test_cli.py
+++ b/tests/unit_tests/test_cli.py
@@ -752,7 +752,7 @@ def test_login_with_unauthenticated_server(
     mock_unauthenticated_server: responses.RequestsMock,
 ):
     result = runner.invoke(main, ["-c", config_with_auth, "login"])
-    assert "Server is not configured to use authentication!" == result.output
+    assert "Server is not configured to use authentication!\n" == result.output
     assert result.exit_code == 0
 
 

--- a/tests/unit_tests/test_cli.py
+++ b/tests/unit_tests/test_cli.py
@@ -746,6 +746,16 @@ def test_login_when_cached_token_decode_fails(
         assert result.exit_code == 0
 
 
+def test_login_with_unauthenticated_server(
+    runner: CliRunner,
+    config_with_auth: str,
+    mock_unauthenticated_server: responses.RequestsMock,
+):
+    result = runner.invoke(main, ["-c", config_with_auth, "login"])
+    assert "Server is not configured to use authentication!" == result.output
+    assert result.exit_code == 0
+
+
 def test_logout_success(
     runner: CliRunner,
     config_with_auth: str,


### PR DESCRIPTION
Allows the `/config/oidc` endpoint to return `204 No Content` instead of a OIDCConfig object. This represents to the client that authentication is not configured/not required, allowing the schema of routes to be consistent whether config if configured or not.

This does not resolve the SecuritySchema being present/absent in the schema.