### PR TITLE
add pydantic level validation for blueapi to not be a valid target

### DIFF
--- a/src/blueapi/cli/scratch.py
+++ b/src/blueapi/cli/scratch.py
@@ -33,7 +33,7 @@ def setup_scratch(
     logging.info(f"Setting up scratch area: {config.root}")
 
     for repo in config.repositories:
-        if repo.remote_url == FORBIDDEN_OWN_REMOTE_URL:
+        if repo.remote_url.lower() == FORBIDDEN_OWN_REMOTE_URL.lower() or repo.name == 'blueapi:
             raise PermissionError(
                 textwrap.dedent("""
         The scratch area cannot be used to clone the blueapi repository.

--- a/src/blueapi/cli/scratch.py
+++ b/src/blueapi/cli/scratch.py
@@ -33,7 +33,10 @@ def setup_scratch(
     logging.info(f"Setting up scratch area: {config.root}")
 
     for repo in config.repositories:
-        if repo.remote_url.lower() == FORBIDDEN_OWN_REMOTE_URL.lower() or repo.name == "blueapi":
+        if (
+            repo.remote_url.lower() == FORBIDDEN_OWN_REMOTE_URL.lower()
+            or repo.name == "blueapi"
+        ):
             raise PermissionError(
                 textwrap.dedent("""
         The scratch area cannot be used to clone the blueapi repository.

--- a/src/blueapi/cli/scratch.py
+++ b/src/blueapi/cli/scratch.py
@@ -31,7 +31,7 @@ def setup_scratch(
     _validate_root_directory(config.root, config.required_gid)
 
     logging.info(f"Setting up scratch area: {config.root}")
-    
+
     """ fail early """
     for repo in config.repositories:
         if (

--- a/src/blueapi/cli/scratch.py
+++ b/src/blueapi/cli/scratch.py
@@ -31,7 +31,8 @@ def setup_scratch(
     _validate_root_directory(config.root, config.required_gid)
 
     logging.info(f"Setting up scratch area: {config.root}")
-
+    
+    """ fail early """
     for repo in config.repositories:
         if (
             repo.remote_url.lower() == FORBIDDEN_OWN_REMOTE_URL.lower()
@@ -43,7 +44,7 @@ def setup_scratch(
         That is to prevent namespace clashing with the blueapi application.
         """)
             )
-
+    for repo in config.repositories:
         local_directory = config.root / repo.name
         ensure_repo(repo.remote_url, local_directory)
         scratch_install(local_directory, timeout=install_timeout)

--- a/src/blueapi/cli/scratch.py
+++ b/src/blueapi/cli/scratch.py
@@ -33,7 +33,7 @@ def setup_scratch(
     logging.info(f"Setting up scratch area: {config.root}")
 
     for repo in config.repositories:
-        if repo.remote_url.lower() == FORBIDDEN_OWN_REMOTE_URL.lower() or repo.name == 'blueapi:
+        if repo.remote_url.lower() == FORBIDDEN_OWN_REMOTE_URL.lower() or repo.name == "blueapi":
             raise PermissionError(
                 textwrap.dedent("""
         The scratch area cannot be used to clone the blueapi repository.

--- a/src/blueapi/cli/scratch.py
+++ b/src/blueapi/cli/scratch.py
@@ -15,6 +15,7 @@ from blueapi.utils import get_owner_gid, is_sgid_set
 
 _DEFAULT_INSTALL_TIMEOUT: float = 300.0
 
+
 def setup_scratch(
     config: ScratchConfig, install_timeout: float = _DEFAULT_INSTALL_TIMEOUT
 ) -> None:

--- a/src/blueapi/config.py
+++ b/src/blueapi/config.py
@@ -13,11 +13,14 @@ from pydantic import (
     Field,
     TypeAdapter,
     ValidationError,
+    field_validator,
 )
 
 from blueapi.utils import BlueapiBaseModel, InvalidConfigError
 
 LogLevel = Literal["NOTSET", "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
+
+FORBIDDEN_OWN_REMOTE_URL = "https://github.com/DiamondLightSource/blueapi.git"
 
 
 class SourceKind(str, Enum):
@@ -90,6 +93,13 @@ class ScratchRepository(BlueapiBaseModel):
         description="URL to clone from",
         default="https://github.com/example/example.git",
     )
+
+    @field_validator("remote_url")
+    @classmethod
+    def check_remote_url(cls, value: str) -> str:
+        if value == FORBIDDEN_OWN_REMOTE_URL:
+            raise ValueError(f"remote_url '{value}' is not allowed.")
+        return value
 
 
 class ScratchConfig(BlueapiBaseModel):

--- a/tests/unit_tests/cli/test_scratch.py
+++ b/tests/unit_tests/cli/test_scratch.py
@@ -188,6 +188,23 @@ def test_setup_scratch_fails_on_wrong_gid(
         setup_scratch(config)
 
 
+def test_setup_scratch_fails_on_blueapi_included(
+    directory_path_with_sgid: Path,
+):
+    b = ScratchRepository.model_construct(
+        name="blueapi",
+        remote_url="https://github.com/DiamondLightSource/blueapi.git",
+    )
+    config = ScratchConfig.model_construct(
+        root=directory_path_with_sgid,
+        required_gid=12345,
+        repositories=[b],
+    )
+    assert get_owner_gid(directory_path_with_sgid) != 12345
+    with pytest.raises(PermissionError):
+        setup_scratch(config)
+
+
 @pytest.mark.skip(
     reason="""
 We can't chown a tempfile in all environments, in particular it

--- a/tests/unit_tests/test_config.py
+++ b/tests/unit_tests/test_config.py
@@ -413,7 +413,7 @@ def test_raises_validation_error(temp_yaml_config_file: dict):
     loader.use_values_from_yaml(temp_yaml_file_path)
     with pytest.raises(InvalidConfigError) as excinfo:
         _loaded_config = loader.load()
-        assert excinfo.value.errors() == [ # type: ignore
+        assert excinfo.value.errors() == [  # type: ignore
             {
                 "loc": ("scratch",),
                 "msg": "The scratch area cannot be used to clone the blueapi repository. That is to prevent namespace clashing with the blueapi application.",  # noqa: E501

--- a/tests/unit_tests/test_config.py
+++ b/tests/unit_tests/test_config.py
@@ -357,6 +357,71 @@ def test_config_yaml_parsed_complete(temp_yaml_config_file: dict):
     )
 
 
+@pytest.mark.parametrize(
+    "temp_yaml_config_file",
+    [
+        {
+            "stomp": {
+                "host": "https://rabbitmq.diamond.ac.uk",
+                "port": 61613,
+                "auth": {"username": "guest", "password": "guest"},
+            },
+            "auth_token_path": None,
+            "env": {
+                "sources": [
+                    {"kind": "dodal", "module": "dodal.adsim"},
+                    {"kind": "planFunctions", "module": "dodal.plans"},
+                    {"kind": "planFunctions", "module": "dodal.plan_stubs.wrapped"},
+                ],
+                "events": {"broadcast_status_events": True},
+                "metadata": {
+                    "instrument_session": "aa123456",
+                    "instrument": "p01",
+                },
+            },
+            "logging": {"level": "INFO"},
+            "api": {"host": "0.0.0.0", "port": 8001, "protocol": "http"},
+            "numtracker": None,
+            "oidc": {
+                "well_known_url": "https://auth.example.com/realms/sample/.well-known/openid-configuration",
+                "client_id": "blueapi-client",
+                "client_audience": "aud",
+            },
+            "scratch": {
+                "root": "/tmp/scratch/blueapi",
+                "required_gid": None,
+                "repositories": [
+                    {
+                        "name": "dodal",
+                        "remote_url": "https://github.com/DiamondLightSource/dodal.git",
+                    },
+                    {
+                        "name": "blueapi",
+                        "remote_url": "https://github.com/DiamondLightSource/blueapi.git",
+                    },
+                ],
+            },
+        },
+    ],
+    indirect=True,
+)
+def test_raises_validation_error(temp_yaml_config_file: dict):
+    temp_yaml_file_path, config_data = temp_yaml_config_file
+
+    # Initialize loader and load config from the YAML file
+    loader = ConfigLoader(ApplicationConfig)
+    loader.use_values_from_yaml(temp_yaml_file_path)
+    with pytest.raises(InvalidConfigError) as excinfo:
+        _loaded_config = loader.load()
+        assert excinfo.value.errors() == [ # type: ignore
+            {
+                "loc": ("scratch",),
+                "msg": "The scratch area cannot be used to clone the blueapi repository. That is to prevent namespace clashing with the blueapi application.",  # noqa: E501
+                "type": "value_error",
+            }
+        ]
+
+
 def test_oauth_config_model_post_init(
     oidc_well_known: dict[str, Any],
     oidc_config: OIDCConfig,


### PR DESCRIPTION
solves #723 

Added a check in scratch.py at the cloning stage (before even pip install). it is kind of redundant - as I also added a check on the pydantic validation of the config that happens earlier than that. The former might be useful if someone chooses to provide config not-through pydantic models - not sure how that would happen but it's more robust that way. Also added a test for parsing the config.

