### PR TITLE
Use optional HTTP Bearer auth when no OIDC config is present

### DIFF
--- a/docs/reference/openapi.yaml
+++ b/docs/reference/openapi.yaml
@@ -338,6 +338,10 @@ components:
       - task_id
       title: WorkerTask
       type: object
+  securitySchemes:
+    HTTPBearer:
+      scheme: bearer
+      type: http
 info:
   title: BlueAPI Control
   version: 0.0.10
@@ -368,6 +372,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/DeviceResponse'
           description: Successful Response
+      security:
+      - HTTPBearer: []
       summary: Get Devices
   /devices/{name}:
     get:
@@ -393,6 +399,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
           description: Validation Error
+      security:
+      - HTTPBearer: []
       summary: Get Device By Name
   /environment:
     delete:
@@ -406,6 +414,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/EnvironmentResponse'
           description: Successful Response
+      security:
+      - HTTPBearer: []
       summary: Delete Environment
     get:
       description: Get the current state of the environment, i.e. initialization state.
@@ -417,6 +427,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/EnvironmentResponse'
           description: Successful Response
+      security:
+      - HTTPBearer: []
       summary: Get Environment
   /healthz:
     get:
@@ -441,6 +453,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/PlanResponse'
           description: Successful Response
+      security:
+      - HTTPBearer: []
       summary: Get Plans
   /plans/{name}:
     get:
@@ -466,6 +480,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
           description: Validation Error
+      security:
+      - HTTPBearer: []
       summary: Get Plan By Name
   /python_environment:
     get:
@@ -505,6 +521,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
           description: Validation Error
+      security:
+      - HTTPBearer: []
       summary: Get Python Environment
   /tasks:
     get:
@@ -532,6 +550,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
           description: Validation Error
+      security:
+      - HTTPBearer: []
       summary: Get Tasks
     post:
       description: Submit a task to the worker.
@@ -560,6 +580,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
           description: Validation Error
+      security:
+      - HTTPBearer: []
       summary: Submit Task
   /tasks/{task_id}:
     delete:
@@ -584,6 +606,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
           description: Validation Error
+      security:
+      - HTTPBearer: []
       summary: Delete Submitted Task
     get:
       description: Retrieve a task
@@ -608,6 +632,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
           description: Validation Error
+      security:
+      - HTTPBearer: []
       summary: Get Task
   /worker/state:
     get:
@@ -620,6 +646,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/WorkerState'
           description: Successful Response
+      security:
+      - HTTPBearer: []
       summary: Get State
     put:
       description: "Request that the worker is put into a particular state.\nReturns\
@@ -658,6 +686,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
           description: Validation Error
+      security:
+      - HTTPBearer: []
       summary: Set State
   /worker/task:
     get:
@@ -669,6 +699,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/WorkerTask'
           description: Successful Response
+      security:
+      - HTTPBearer: []
       summary: Get Active Task
     put:
       description: 'Set a task to active status, the worker should begin it as soon
@@ -697,4 +729,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
           description: Validation Error
+      security:
+      - HTTPBearer: []
       summary: Set Active Task

--- a/src/blueapi/service/main.py
+++ b/src/blueapi/service/main.py
@@ -13,7 +13,7 @@ from fastapi import (
     Response,
     status,
 )
-from fastapi.security import OAuth2AuthorizationCodeBearer
+from fastapi.security import HTTPBearer, OAuth2AuthorizationCodeBearer
 from observability_utils.tracing import (
     add_span_attributes,
     get_tracer,
@@ -108,6 +108,8 @@ def get_app(config: ApplicationConfig):
     dependencies = []
     if config.oidc:
         dependencies.append(Depends(verify_access_token(config.oidc)))
+    else:
+        dependencies.append(Depends(HTTPBearer(auto_error=False)))
     app.include_router(open_router)
     app.include_router(secure_router, dependencies=dependencies)
     app.add_exception_handler(KeyError, on_key_error_404)


### PR DESCRIPTION
Allows the schema to have enough information without having to include DLS configuration in the repo schema.