### PR TITLE
fix: Return validation error details from submit_task

### DIFF
--- a/src/blueapi/service/main.py
+++ b/src/blueapi/service/main.py
@@ -272,10 +272,11 @@ def submit_task(
         # fields defined in the generated schema are present
         errors = [
             {
-                **err,
                 "loc": ["body", "params", *err.get("loc", [])],
                 "msg": err.get("msg", None),
                 "type": err.get("type", None),
+                # Input is not listed as required but is useful to have if available
+                "input": err.get("input", None),
             }
             for err in e.errors()
         ]

--- a/tests/unit_tests/service/test_rest_api.py
+++ b/tests/unit_tests/service/test_rest_api.py
@@ -258,7 +258,6 @@ def test_create_task_validation_error(mock_runner: Mock, client: TestClient) -> 
                 "loc": ["body", "params", "id"],
                 "msg": "Field required",
                 "type": "missing",
-                "url": "https://errors.pydantic.dev/2.10/v/missing",
             }
         ]
     }


### PR DESCRIPTION
Ensures that validation errors from within plan parameters are presented
in the same way as those encountered parsing the top level arguments to
the method/endpoint.

Fixes #916

### Instructions to reviewer on how to test:
1. Run server with example plans/devices
2. `curl -XPOST localhost:8000/tasks -d '{"name":"stp_snapshot", "params": {"detectors":"not a list"}}' -H 'Content-Type: application/json'`
3. Check that the returned json matches the `HTTPValidationError` spec in the openapi spec

### Checks for reviewer
- [ ] Would the PR title make sense to a user on a set of release notes
