### PR TITLE
feat: Enable/disable stomp with a flag in config

### DIFF
--- a/docs/tutorials/run-bus.md
+++ b/docs/tutorials/run-bus.md
@@ -22,12 +22,12 @@ Create a YAML file for configuring blueapi:
 # if it has different credentials, 
 # or if its STOMP plugin is running on a different port
 stomp:
+    enabled: true  # All other stomp settings will be ignored if this is false
     host: localhost
     port: 61613
     auth:
         username: guest
-        # This is for local development only, production systems should use good passwords
-        password: guest
+        password: guest  # This is for local development only, production systems should use good passwords
 ```
 
 ## Run the Server

--- a/helm/blueapi/values.yaml
+++ b/helm/blueapi/values.yaml
@@ -107,6 +107,7 @@ worker:
     - kind: planFunctions
       module: dodal.plan_stubs.wrapped
   stomp:
+    enabled: false
     auth:
       username: guest
       password: guest

--- a/src/blueapi/cli/cli.py
+++ b/src/blueapi/cli/cli.py
@@ -177,7 +177,7 @@ def get_devices(obj: dict) -> None:
 def listen_to_events(obj: dict) -> None:
     """Listen to events output by blueapi"""
     config: ApplicationConfig = obj["config"]
-    assert config.stomp is not None, "Message bus needs to be configured"
+    assert config.stomp.enabled, "Message bus needs to be configured"
     event_bus_client = EventBusClient(
         StompClient.for_broker(
             broker=Broker(

--- a/src/blueapi/cli/cli.py
+++ b/src/blueapi/cli/cli.py
@@ -177,7 +177,8 @@ def get_devices(obj: dict) -> None:
 def listen_to_events(obj: dict) -> None:
     """Listen to events output by blueapi"""
     config: ApplicationConfig = obj["config"]
-    assert config.stomp.enabled, "Message bus needs to be configured"
+    if not config.stomp.enabled:
+        raise BlueskyStreamingError("Message bus needs to be configured")
     event_bus_client = EventBusClient(
         StompClient.for_broker(
             broker=Broker(

--- a/src/blueapi/client/client.py
+++ b/src/blueapi/client/client.py
@@ -55,17 +55,18 @@ class BlueapiClient:
         except Exception:
             ...  # Swallow exceptions
         rest = BlueapiRestClient(config.api, session_manager=session_manager)
-        if config.stomp is None:
-            return cls(rest)
-        client = StompClient.for_broker(
-            broker=Broker(
-                host=config.stomp.host,
-                port=config.stomp.port,
-                auth=config.stomp.auth,
+        if config.stomp.enabled:
+            client = StompClient.for_broker(
+                broker=Broker(
+                    host=config.stomp.host,
+                    port=config.stomp.port,
+                    auth=config.stomp.auth,
+                )
             )
-        )
-        events = EventBusClient(client)
-        return cls(rest, events)
+            events = EventBusClient(client)
+            return cls(rest, events)
+        else:
+            return cls(rest)
 
     @start_as_current_span(TRACER)
     def get_plans(self) -> PlanResponse:

--- a/src/blueapi/config.py
+++ b/src/blueapi/config.py
@@ -44,9 +44,12 @@ class StompConfig(BlueapiBaseModel):
         "event publishing",
         default=False,
     )
-    host: str = "localhost"
-    port: int = 61613
-    auth: BasicAuthentication | None = None
+    host: str = Field(description="STOMP broker host", default="localhost")
+    port: int = Field(description="STOMP broker port", default=61613)
+    auth: BasicAuthentication | None = Field(
+        description="Auth information for communicating with STOMP broker, if required",
+        default=None,
+    )
 
 
 class WorkerEventConfig(BlueapiBaseModel):

--- a/src/blueapi/config.py
+++ b/src/blueapi/config.py
@@ -39,6 +39,11 @@ class StompConfig(BlueapiBaseModel):
     Config for connecting to stomp broker
     """
 
+    enabled: bool = Field(
+        description="True if blueapi should connect to stomp for asynchronous "
+        "event publishing",
+        default=False,
+    )
     host: str = "localhost"
     port: int = 61613
     auth: BasicAuthentication | None = None
@@ -194,7 +199,7 @@ class ApplicationConfig(BlueapiBaseModel):
     config tree.
     """
 
-    stomp: StompConfig | None = None
+    stomp: StompConfig = Field(default_factory=StompConfig)
     env: EnvironmentConfig = Field(default_factory=EnvironmentConfig)
     logging: LoggingConfig = Field(default_factory=LoggingConfig)
     api: RestConfig = Field(default_factory=RestConfig)

--- a/src/blueapi/service/interface.py
+++ b/src/blueapi/service/interface.py
@@ -61,8 +61,8 @@ def worker() -> TaskWorker:
 
 @cache
 def stomp_client() -> StompClient | None:
-    stomp_config: StompConfig | None = config().stomp
-    if stomp_config is not None:
+    stomp_config: StompConfig = config().stomp
+    if stomp_config.enabled:
         client = StompClient.for_broker(
             broker=Broker(
                 host=stomp_config.host,

--- a/tests/system_tests/test_blueapi_system.py
+++ b/tests/system_tests/test_blueapi_system.py
@@ -60,7 +60,8 @@ def client_with_stomp() -> BlueapiClient:
     return BlueapiClient.from_config(
         config=ApplicationConfig(
             stomp=StompConfig(
-                auth=BasicAuthentication(username="guest", password="guest")  # type: ignore
+                enabled=True,
+                auth=BasicAuthentication(username="guest", password="guest"),  # type: ignore
             )
         )
     )

--- a/tests/unit_tests/example_yaml/rest_and_stomp_config.yaml
+++ b/tests/unit_tests/example_yaml/rest_and_stomp_config.yaml
@@ -1,0 +1,7 @@
+api:
+  host: a.fake.host
+  port: 12345
+stomp:
+  enabled: true
+  host: localhost
+  port: 61613

--- a/tests/unit_tests/example_yaml/rest_config.yaml
+++ b/tests/unit_tests/example_yaml/rest_config.yaml
@@ -2,5 +2,6 @@ api:
   host: a.fake.host
   port: 12345
 stomp:
+  enabled: true
   host: localhost
   port: 61613

--- a/tests/unit_tests/example_yaml/rest_config.yaml
+++ b/tests/unit_tests/example_yaml/rest_config.yaml
@@ -1,7 +1,3 @@
 api:
   host: a.fake.host
   port: 12345
-stomp:
-  enabled: true
-  host: localhost
-  port: 61613

--- a/tests/unit_tests/example_yaml/valid_stomp_config.yaml
+++ b/tests/unit_tests/example_yaml/valid_stomp_config.yaml
@@ -1,3 +1,4 @@
 stomp:
+  enabled: true
   host: localhost
   port: 61613

--- a/tests/unit_tests/service/test_interface.py
+++ b/tests/unit_tests/service/test_interface.py
@@ -331,8 +331,17 @@ def test_stomp_config(mock_stomp_client: StompClient):
         "blueapi.service.interface.StompClient.for_broker",
         return_value=mock_stomp_client,
     ):
-        interface.set_config(ApplicationConfig(stomp=StompConfig()))
+        interface.set_config(ApplicationConfig(stomp=StompConfig(enabled=True)))
         assert interface.stomp_client() is not None
+
+
+def test_stomp_config_makes_no_client_when_disabled(mock_stomp_client: StompClient):
+    with patch(
+        "blueapi.service.interface.StompClient.for_broker",
+        return_value=mock_stomp_client,
+    ):
+        interface.set_config(ApplicationConfig(stomp=StompConfig(enabled=False)))
+        assert interface.stomp_client() is None
 
 
 @patch("blueapi.cli.scratch._fetch_installed_packages_details")

--- a/tests/unit_tests/test_cli.py
+++ b/tests/unit_tests/test_cli.py
@@ -25,6 +25,7 @@ from stomp.connect import StompConnection11 as Connection
 from blueapi import __version__
 from blueapi.cli.cli import main
 from blueapi.cli.format import OutputFormat, fmt_dict
+from blueapi.client.event_bus import BlueskyStreamingError
 from blueapi.client.rest import BlueskyRemoteControlError
 from blueapi.config import ApplicationConfig, ScratchConfig, ScratchRepository
 from blueapi.core.bluesky_types import DataEvent, Plan
@@ -214,7 +215,7 @@ def test_submit_plan_without_stomp(runner: CliRunner):
 
 def test_invalid_stomp_config_for_listener(runner: CliRunner):
     result = runner.invoke(main, ["controller", "listen"])
-    assert isinstance(result.exception, AssertionError)
+    assert isinstance(result.exception, BlueskyStreamingError)
     assert str(result.exception) == "Message bus needs to be configured"
 
 

--- a/tests/unit_tests/test_cli.py
+++ b/tests/unit_tests/test_cli.py
@@ -191,12 +191,25 @@ def test_submit_plan(runner: CliRunner):
         match=[matchers.json_params_matcher(body_data)],
     )
 
-    config_path = "tests/unit_tests/example_yaml/rest_config.yaml"
+    config_path = "tests/unit_tests/example_yaml/rest_and_stomp_config.yaml"
     runner.invoke(
         main, ["-c", config_path, "controller", "run", "sleep", '{"time": 5}']
     )
 
     assert response.call_count == 1
+
+
+@responses.activate
+def test_submit_plan_without_stomp(runner: CliRunner):
+    config_path = "tests/unit_tests/example_yaml/rest_config.yaml"
+    result = runner.invoke(
+        main, ["-c", config_path, "controller", "run", "sleep", '{"time": 5}']
+    )
+
+    assert (
+        str(result.exception)
+        == "Cannot run plans without Stomp configuration to track progress"
+    )
 
 
 def test_invalid_stomp_config_for_listener(runner: CliRunner):

--- a/tests/unit_tests/test_config.py
+++ b/tests/unit_tests/test_config.py
@@ -211,7 +211,7 @@ def temp_yaml_config_file(
             "api": {"host": "0.0.0.0", "port": 8000},
         },
         {
-            "stomp": None,
+            "stomp": {"enabled": True},
             "env": {
                 "sources": [
                     {"kind": "dodal", "module": "dodal.adsim"},
@@ -255,6 +255,7 @@ def test_config_yaml_parsed(temp_yaml_config_file):
         # Different configuration examples passed to the fixture
         {
             "stomp": {
+                "enabled": True,
                 "host": "localhost",
                 "port": 61613,
                 "auth": {"username": "guest", "password": "guest"},
@@ -307,6 +308,7 @@ def test_config_yaml_parsed(temp_yaml_config_file):
         },
         {
             "stomp": {
+                "enabled": True,
                 "host": "https://rabbitmq.diamond.ac.uk",
                 "port": 61613,
                 "auth": {"username": "guest", "password": "guest"},
@@ -369,7 +371,6 @@ def test_config_yaml_parsed_complete(temp_yaml_config_file: dict):
     # Parse the loaded config JSON into a dictionary
     target_dict_json = json.loads(loaded_config.model_dump_json())
 
-    assert loaded_config.stomp is not None
     assert loaded_config.stomp.auth is not None
     assert (
         loaded_config.stomp.auth.password.get_secret_value()

--- a/tests/unit_tests/test_helm_chart.py
+++ b/tests/unit_tests/test_helm_chart.py
@@ -58,8 +58,10 @@ LOW_RESOURCES = {
     [
         ApplicationConfig(),
         ApplicationConfig(stomp=StompConfig()),
+        ApplicationConfig(stomp=StompConfig(enabled=True)),
         ApplicationConfig(
             stomp=StompConfig(
+                enabled=True,
                 host="example.com",
                 port=515,
             ),

--- a/tests/unit_tests/test_helm_chart.py
+++ b/tests/unit_tests/test_helm_chart.py
@@ -184,7 +184,6 @@ def test_helm_chart_does_not_render_arbitrary_rabbitmq_password():
             manifests["ConfigMap"]["blueapi-config"]["data"]["config.yaml"]
         )
     )
-    assert rendered_config.stomp is not None
     assert rendered_config.stomp.auth is not None
     assert isinstance(rendered_config.stomp.auth.password, Secret)
 


### PR DESCRIPTION
Fixes #919 

BREAKING CHANGE: Stomp configuration is now disabled by default in the helm chart. To make blueapi connect to a stomp message broker you have to include`enabled: true` under `worker.stomp` in your `values.yaml` file. 