### PR TITLE
fix: Use consistent naming for reference type errors

### DIFF
--- a/src/blueapi/core/context.py
+++ b/src/blueapi/core/context.py
@@ -66,6 +66,14 @@ def qualified_name(target: type) -> str:
     return f"{module_name}{name}"
 
 
+def qualified_generic_name(target: type) -> str:
+    args = get_args(target)
+    subscript = (
+        "[" + ", ".join(qualified_name(arg) for arg in args) + "]" if args else ""
+    )
+    return f"{qualified_name(target)}{subscript}"
+
+
 def is_bluesky_type(typ: type) -> bool:
     return typ in BLUESKY_PROTOCOLS or isinstance(typ, BLUESKY_PROTOCOLS)
 
@@ -251,7 +259,10 @@ class BlueskyContext:
                         if not val or not is_compatible(
                             val, cls.origin or target, cls.args
                         ):
-                            raise ValueError(f"Device {value} is not of type {target}")
+                            required = qualified_generic_name(target)
+                            raise ValueError(
+                                f"Device {value} is not of type {required}"
+                            )
                         return val
 
                     return core_schema.no_info_after_validator_function(


### PR DESCRIPTION
When running a plan with invalid parameters, the error message would be different depending on whether the required type was generic or not, eg (with #935) 

```
$ uv run --prerelease=allow blueapi -c conf.yaml controller run stp_snapshot '{"detectors": ["xyz"], "pressure": "foo"}'
Error: Incorrect parameters supplied
    Invalid value 'xyz' for field detectors.0: Value error, Device xyz is not of type <class 'bluesky.protocols.Readable'>
    Invalid value 'foo' for field pressure: Value error, Device foo is not of type bluesky.protocols.Movable[float]
```

where `<class 'bluesky.protocols.Readable'>` and `bluesky.protocols.Movable[float]` should be the same format.

Fixes #934 