### PR TITLE
feat!: Add task_id to DataEvents

### DIFF
--- a/src/blueapi/core/bluesky_types.py
+++ b/src/blueapi/core/bluesky_types.py
@@ -103,6 +103,7 @@ class DataEvent(BlueapiBaseModel):
 
     name: str
     doc: Mapping[str, Any]
+    task_id: str
 
 
 @runtime_checkable

--- a/src/blueapi/worker/task_worker.py
+++ b/src/blueapi/worker/task_worker.py
@@ -465,7 +465,10 @@ class TaskWorker:
 
                     correlation_id = self._current.request_id
                     self._data_events.publish(
-                        DataEvent(name=name, task_id=self._current.task_id, doc=document), correlation_id
+                        DataEvent(
+                            name=name, task_id=self._current.task_id, doc=document
+                        ),
+                        correlation_id,
                     )
             else:
                 raise ValueError(

--- a/src/blueapi/worker/task_worker.py
+++ b/src/blueapi/worker/task_worker.py
@@ -465,7 +465,7 @@ class TaskWorker:
 
                     correlation_id = self._current.request_id
                     self._data_events.publish(
-                        DataEvent(name=name, doc=document), correlation_id
+                        DataEvent(name=name, task_id=self._current.task_id, doc=document), correlation_id
                     )
             else:
                 raise ValueError(

--- a/tests/unit_tests/client/test_client.py
+++ b/tests/unit_tests/client/test_client.py
@@ -434,7 +434,7 @@ def test_run_task_fails_on_failing_event(
             ),
         ),
         ProgressEvent(task_id="foo"),
-        DataEvent(name="start", doc={}),
+        DataEvent(name="start", doc={}, task_id="0000-1111"),
     ],
 )
 def test_run_task_calls_event_callback(

--- a/tests/unit_tests/test_cli.py
+++ b/tests/unit_tests/test_cli.py
@@ -657,7 +657,9 @@ def test_plan_output_formatting():
 
 def test_event_formatting():
     data = DataEvent(
-        name="start", doc={"foo": "bar", "fizz": {"buzz": (1, 2, 3), "hello": "world"}}
+        name="start",
+        doc={"foo": "bar", "fizz": {"buzz": (1, 2, 3), "hello": "world"}},
+        task_id="0000-1111",
     )
     worker = WorkerEvent(
         state=WorkerState.RUNNING,
@@ -672,7 +674,8 @@ def test_event_formatting():
         data,
         (
             """{"name": "start", "doc": """
-            """{"foo": "bar", "fizz": {"buzz": [1, 2, 3], "hello": "world"}}}\n"""
+            """{"foo": "bar", "fizz": {"buzz": [1, 2, 3], "hello": "world"}}, """
+            """"task_id": "0000-1111"}\n"""
         ),
     )
     _assert_matching_formatting(OutputFormat.COMPACT, data, "Data Event: start\n")

--- a/tests/unit_tests/worker/test_task_worker.py
+++ b/tests/unit_tests/worker/test_task_worker.py
@@ -389,10 +389,10 @@ def test_worker_and_data_events_produce_in_order(
                 errors=[],
                 warnings=[],
             ),
-            DataEvent(name="start", doc={}),
-            DataEvent(name="descriptor", doc={}),
-            DataEvent(name="event", doc={}),
-            DataEvent(name="stop", doc={}),
+            DataEvent(name="start", doc={}, task_id="0000-1111"),
+            DataEvent(name="descriptor", doc={}, task_id="0000-1111"),
+            DataEvent(name="event", doc={}, task_id="0000-1111"),
+            DataEvent(name="stop", doc={}, task_id="0000-1111"),
             WorkerEvent(
                 state=WorkerState.IDLE,
                 task_status=TaskStatus(


### PR DESCRIPTION
Including the task_id in the data events (wrapped messages from run engine),
allows clients to filter messages to the specific task that they are
interested.

For instance, in the "submit task => start listening to events => start task"
exchange, it is useful to be able to ignore events received before the start
task fails due to another task running.
