### PR TITLE
fix: Pin click to minimum version with default seperated stdout/stderr

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -18,7 +18,7 @@ certifi==2025.1.31
 cffi==1.17.1
 cfgv==3.4.0
 charset-normalizer==3.4.1
-click==8.1.8
+click==8.2.0
 colorama==0.4.6
 colorlog==6.9.0
 compress-pickle==2.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "stomp-py",
     "aiohttp",
     "PyYAML>=6.0.2",
-    "click",
+    "click>=8.2.0",
     "fastapi>=0.112.0",
     "uvicorn",
     "requests",

--- a/tests/unit_tests/test_cli.py
+++ b/tests/unit_tests/test_cli.py
@@ -218,7 +218,7 @@ def test_submit_plan_without_stomp(runner: CliRunner):
     )
 
     assert (
-        result.stdout
+        result.stderr
         == "Error: Stomp configuration required to run plans is missing or disabled\n"
     )
 
@@ -233,7 +233,7 @@ def test_cannot_run_plans_without_stomp_config(runner: CliRunner):
     result = runner.invoke(main, ["controller", "run", "sleep", '{"time": 5}'])
     assert result.exit_code == 1
     assert (
-        result.stdout
+        result.stderr
         == "Error: Stomp configuration required to run plans is missing or disabled\n"
     )
 
@@ -466,7 +466,7 @@ def test_error_handling(exception, error_message, runner: CliRunner):
             ],
         )
     # error message is printed to stderr but test runner combines output
-    assert result.stdout == error_message
+    assert result.stderr == error_message
     assert result.exit_code == 1
 
 
@@ -490,7 +490,7 @@ def test_run_task_parsing_errors(params: str, error: str, runner: CliRunner):
         ],
     )
     # error message is printed to stderr but test runner combines output
-    assert result.stdout.startswith("Error: " + error)
+    assert result.stderr.startswith("Error: " + error)
     assert result.exit_code == 1
 
 


### PR DESCRIPTION
click [version 8.2.0](https://github.com/pallets/click/releases/tag/8.2.0) tracks stdout and stderr separately by default, where previously they were unified unless explicitly requested.

We pin to >=8.2.0 (which also drops support for versions of python we do not support either anymore, and so is likely to be using more modern code and practices) and replace the handling in tests that expected to use stderr. There are other tests that check stdout, and we should ensure that we pipe to stdout and stderr correctly.