### PR TITLE
chore: Remove outdated comments on cli output streams

### DIFF
--- a/tests/unit_tests/test_cli.py
+++ b/tests/unit_tests/test_cli.py
@@ -465,7 +465,6 @@ def test_error_handling(exception, error_message, runner: CliRunner):
                 '{"time": 5}',
             ],
         )
-    # error message is printed to stderr but test runner combines output
     assert result.stderr == error_message
     assert result.exit_code == 1
 
@@ -489,7 +488,6 @@ def test_run_task_parsing_errors(params: str, error: str, runner: CliRunner):
             params,
         ],
     )
-    # error message is printed to stderr but test runner combines output
     assert result.stderr.startswith("Error: " + error)
     assert result.exit_code == 1
 


### PR DESCRIPTION
The streams are no longer combined (see #946 and click #2523) and
streams can be checked individually in tests.
