### PR TITLE
ci: Group dependencies that are updated by the copier template

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:best-practices"
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,27 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:best-practices"
+  ],
+  "packageRules": [
+    {
+      "groupName": "Templated CI",
+      "matchDepNames": [
+        "actions/checkout",
+        "actions/download-artifact",
+        "actions/setup-python",
+        "actions/upload-artifact",
+        "codecov/codecov-action",
+        "docker/build-push-action",
+        "docker/login-action",
+        "docker/metadata-action",
+        "docker/setup-buildx-action",
+        "peaceiris/actions-gh-pages",
+        "pypa/gh-action-pypi-publish",
+        "softprops/action-gh-release"
+      ],
+      "description": [
+        "Group and update GitHub actions through the copier template to prevent merge conflicts"
+      ]
+    }
   ]
 }


### PR DESCRIPTION
Prevents the state where we have updated beyond the copier template and it's unclear as the actions are pinned to commit SHA, so we revert only to be updated again.
Will require checking: Are we using these actions outside of the files generated by the copier template (e.g. in our Helm build?), possibly re-generating our CI with the latest version of the template. Also assumes that the copier template adopts automation