### PR TITLE
fix: Handle exceptions when logging out

### DIFF
--- a/src/blueapi/cli/cli.py
+++ b/src/blueapi/cli/cli.py
@@ -1,8 +1,8 @@
 import json
+import logging
 import os
 import stat
 import sys
-import logging
 from functools import wraps
 from pathlib import Path
 from pprint import pprint
@@ -428,6 +428,8 @@ def logout(obj: dict) -> None:
         print("Logged out")
     except ValueError as e:
         logging.debug("Invalid login token: %s", e)
-        raise ClickException(f"Login token is not valid - remove before trying again") from e
+        raise ClickException(
+            "Login token is not valid - remove before trying again"
+        ) from e
     except Exception as e:
-        raise ClickException(f'Error logging out: {e}') from e
+        raise ClickException(f"Error logging out: {e}") from e

--- a/src/blueapi/cli/cli.py
+++ b/src/blueapi/cli/cli.py
@@ -2,6 +2,7 @@ import json
 import os
 import stat
 import sys
+import logging
 from functools import wraps
 from pathlib import Path
 from pprint import pprint
@@ -425,3 +426,8 @@ def logout(obj: dict) -> None:
         auth.logout()
     except FileNotFoundError:
         print("Logged out")
+    except ValueError as e:
+        logging.debug("Invalid login token: %s", e)
+        raise ClickException(f"Login token is not valid - remove before trying again") from e
+    except Exception as e:
+        raise ClickException(f'Error logging out: {e}') from e

--- a/tests/unit_tests/test_cli.py
+++ b/tests/unit_tests/test_cli.py
@@ -855,6 +855,27 @@ def test_logout_success(
     assert not cached_valid_refresh.exists()
 
 
+def test_logout_invalid_token(runner: CliRunner):
+    with patch("blueapi.cli.cli.SessionManager") as sm:
+        sm.from_cache.side_effect = ValueError("Invalid token")
+        result = runner.invoke(main, ["logout"])
+
+    assert result.exit_code == 1
+    assert (
+        result.output
+        == "Error: Login token is not valid - remove before trying again\n"
+    )
+
+
+def test_logout_unknown_error(runner: CliRunner):
+    with patch("blueapi.cli.cli.SessionManager") as sm:
+        sm.from_cache.side_effect = Exception("Invalid token")
+        result = runner.invoke(main, ["logout"])
+
+    assert result.exit_code == 1
+    assert result.output == "Error: Error logging out: Invalid token\n"
+
+
 def test_logout_when_no_cache(
     runner: CliRunner,
     config_with_auth: str,


### PR DESCRIPTION
Still doesn't do anything about them but it no longer throws a
stacktrace at the user.

Fixes #894

### Instructions to reviewer on how to test:
1. rm ~/.cache/blueapi_cache
2. touch ~/.cache/blueapi_cache
3. blueapi logout
4. Behold lack of stacktrace

### Checks for reviewer
- [x] Would the PR title make sense to a user on a set of release notes
