### PR TITLE
chore: Reduce noisiness of Renovate PRs

### DIFF
--- a/.github/actions/install_requirements/action.yml
+++ b/.github/actions/install_requirements/action.yml
@@ -15,7 +15,7 @@ runs:
       run: |
         PYTHON_VERSION="${{ inputs.python-version }}"
         if [ $PYTHON_VERSION == "dev" ]; then
-          PYTHON_VERSION=$(sed -n "s/ARG PYTHON_VERSION=//p" Dockerfile)
+          PYTHON_VERSION=$(sed -ne "s/ARG PYTHON_VERSION=//" -e "s/@.*//p" Dockerfile)
         fi
         echo "PYTHON_VERSION=$PYTHON_VERSION" >> "$GITHUB_ENV"
       shell: bash

--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,14 @@
   "extends": [
     "config:best-practices",
     ":automergeStableNonMajor"
+  ],
+  "packageRules": [
+    {
+      "matchUpdateTypes": "patch",
+      "matchManagers": [
+        "pip_requirements"
+      ],
+      "description": "Group indirect python patch versions together"
+    }
   ]
 }


### PR DESCRIPTION
Reduces the noisiness of Renovate PRs by grouping indirect dependencies (those specified in dev-requirements.txt, not those in pyproject.toml). Also fixes the pinning to a particular Python container version