### PR TITLE
Change `image.tag` from hash to actual tag

### DIFF
--- a/.github/workflows/_container.yml
+++ b/.github/workflows/_container.yml
@@ -59,7 +59,27 @@ jobs:
           tags: |
             type=ref,event=tag
             type=raw,value=latest
-
+      
+      - name: Create tags for publishing debug image
+        id: debug-meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=ref,event=tag,suffix=-debug
+            type=raw,value=latest-debug
+      
+      - name: Build and publish debug image to container registry
+        if: github.ref_type == 'tag'
+        uses: docker/build-push-action@v6
+        env:
+          DOCKER_BUILD_RECORD_UPLOAD: false
+        with:
+          context: .
+          push: true
+          target: debug
+          tags: ${{ steps.debug-meta.outputs.tags }}
+            
       - name: Push cached image to container registry
         if: github.ref_type == 'tag'
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6

--- a/helm/blueapi/templates/statefulset.yaml
+++ b/helm/blueapi/templates/statefulset.yaml
@@ -52,6 +52,14 @@ spec:
         emptyDir:
           sizeLimit: 5Gi
       {{- end }}
+      {{- if .Values.debug.enabled }}
+      - name: home  # Required for vscode to install plugins
+        emptyDir:
+          sizeLimit: 500Mi
+      - name: nslcd  # Shared volume between main and sidecar container
+        emptyDir:
+          sizeLimit: 5Mi
+      {{- end }}      
       {{- if .Values.initContainer.enabled }}
       initContainers:
       - name: setup-scratch
@@ -81,7 +89,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}{{ ternary "-debug" "" .Values.debug.enabled }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
@@ -96,15 +104,31 @@ spec:
             - name: venv
               mountPath: /venv
             {{- end }}
+            {{- if .Values.debug.enabled }}
+            - mountPath: /home
+              name: home
+            - mountPath: /var/run/nslcd
+              name: nslcd
+            {{- end }}
+          {{- if not .Values.debug.enabled }}
           args:
             - "-c"
             - "/config/config.yaml"
             - "serve"
+          {{ end }}
           envFrom:
             - configMapRef:
                 name: {{ include "blueapi.fullname" . }}-otel-config
           env:
             {{- toYaml .Values.extraEnvVars | nindent 12 }}
+        {{- if .Values.debug.enabled }}
+        - name: debug-account-sync
+          image: ghcr.io/diamondlightsource/account-sync-sidecar:3.0.0
+          volumeMounts:
+          # This allows the nslcd socket to be shared between the main container and the sidecar
+          - mountPath: /var/run/nslcd
+            name: nslcd
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm/blueapi/values.yaml
+++ b/helm/blueapi/values.yaml
@@ -126,3 +126,6 @@ worker:
       port: 12232
 initContainer:
   enabled: false
+
+debug:
+  enabled: false

--- a/helm/blueapi/values.yaml
+++ b/helm/blueapi/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: ghcr.io/diamondlightsource/blueapi
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "@sha256:2c01159e73c991b4753c3b446b60fdac47d66c985c26636cfb4b0d7649b2b733"
+  tag: "0.14.0-alpha3"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
In `values.yaml` the `image.tag` field uses a hash. This breaks when trying to target the debug container, which appends `-debug` to the end of the gchr url.