### PR TITLE
Remove image tag

### DIFF
--- a/helm/blueapi/values.yaml
+++ b/helm/blueapi/values.yaml
@@ -8,7 +8,8 @@ image:
   repository: ghcr.io/diamondlightsource/blueapi
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "@sha256:2c01159e73c991b4753c3b446b60fdac47d66c985c26636cfb4b0d7649b2b733"
+  # Do not set this to a package hash: https://github.com/DiamondLightSource/blueapi/issues/1046
+  tag: ""
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
Sets `.Values.image.tag` to empty string, adds comment warning not to use package hash.

See https://github.com/DiamondLightSource/blueapi/issues/1046