### PR TITLE
ci: Add CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @developers-daq-core
+* @DiamondLightSource/developers-daq-core

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @developers-daq-core


### PR DESCRIPTION
Add CODEOWNERS of the DAQ core team, to allow opening the repository up to general editing but require an approving code review from a CODEOWNER, rather than allowing all members of the org to contribute and review simultaneously. This is intended as a living document and is not an end to discussion on codeownership, just a reflection of the current state.