### PR TITLE
fix: Ensure blueapi is editable install when using initContainer

### DIFF
--- a/helm/blueapi/templates/statefulset.yaml
+++ b/helm/blueapi/templates/statefulset.yaml
@@ -69,7 +69,7 @@ spec:
       {{- if .Values.initContainer.enabled }}
       initContainers:
       - name: setup-scratch
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}{{ ternary "-debug" "" .Values.debug.enabled }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         resources:
           {{- .Values.initResources | default .Values.resources | toYaml | nindent 12 }}

--- a/tests/unit_tests/test_helm_chart.py
+++ b/tests/unit_tests/test_helm_chart.py
@@ -664,20 +664,26 @@ def test_container_image_has_debug_suffix(
     )
 
     if debug_enabled:
-        assert (
-            manifests["StatefulSet"]["blueapi"]["spec"]["template"]["spec"][
-                "containers"
-            ][0]["image"][-6:]
-            == "-debug"
-        )
+        image = manifests["StatefulSet"]["blueapi"]["spec"]["template"]["spec"][
+            "containers"
+        ][0]["image"]
+        assert str(image).endswith("-debug")
+        if initContainer_enabled:
+            init_image = manifests["StatefulSet"]["blueapi"]["spec"]["template"][
+                "spec"
+            ]["initContainers"][0]["image"]
+            assert init_image == image
 
     else:
-        assert not (
-            manifests["StatefulSet"]["blueapi"]["spec"]["template"]["spec"][
-                "containers"
-            ][0]["image"][-6:]
-            == "-debug"
-        )
+        image = manifests["StatefulSet"]["blueapi"]["spec"]["template"]["spec"][
+            "containers"
+        ][0]["image"]
+        assert not str(image).endswith("-debug")
+        if initContainer_enabled:
+            init_image = manifests["StatefulSet"]["blueapi"]["spec"]["template"][
+                "spec"
+            ]["initContainers"][0]["image"]
+            assert init_image == image
 
 
 @pytest.mark.parametrize("initContainer_enabled", [True, False])

--- a/tests/unit_tests/test_helm_chart.py
+++ b/tests/unit_tests/test_helm_chart.py
@@ -668,22 +668,18 @@ def test_container_image_has_debug_suffix(
             "containers"
         ][0]["image"]
         assert str(image).endswith("-debug")
-        if initContainer_enabled:
-            init_image = manifests["StatefulSet"]["blueapi"]["spec"]["template"][
-                "spec"
-            ]["initContainers"][0]["image"]
-            assert init_image == image
 
     else:
         image = manifests["StatefulSet"]["blueapi"]["spec"]["template"]["spec"][
             "containers"
         ][0]["image"]
         assert not str(image).endswith("-debug")
-        if initContainer_enabled:
-            init_image = manifests["StatefulSet"]["blueapi"]["spec"]["template"][
-                "spec"
-            ]["initContainers"][0]["image"]
-            assert init_image == image
+
+    if initContainer_enabled:
+        init_image = manifests["StatefulSet"]["blueapi"]["spec"]["template"]["spec"][
+            "initContainers"
+        ][0]["image"]
+        assert init_image == image
 
 
 @pytest.mark.parametrize("initContainer_enabled", [True, False])


### PR DESCRIPTION
Prior to this change, if using an initContainer to setupScratch, the editable install of blueapi that was created by the debug stage of the Dockerfile was overwritten by the non-editable install installed into the venv of the init container when the venv overwrote the main containers.