### PR TITLE
fix: Propagate release notes into renovate PRs

### DIFF
--- a/helm/blueapi/Chart.yaml
+++ b/helm/blueapi/Chart.yaml
@@ -1,5 +1,6 @@
 apiVersion: v2
 name: blueapi
+home: https://github.com/DiamondLightSource/blueapi
 description: A helm chart deploying a worker pod that runs Bluesky plans
 
 # A chart can be either an 'application' or a 'library' chart.


### PR DESCRIPTION
By adding `home` field to the Helm chart, we allow Renovate to propagate either a link to the chart or release notes into the automated PR it makes.

cite: https://github.com/renovatebot/renovate/blob/39fb4207bc268ea83114b58bc0414339620c7416/lib/modules/datasource/helm/index.ts#L29