### PR TITLE
docs: Update `component_owner` for backstage

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -4,7 +4,7 @@ _src_path: https://github.com/DiamondLightSource/python-copier-template
 author_email: callum.forrester@diamond.ac.uk
 author_name: Callum Forrester
 component_lifecycle: production
-component_owner: user:vid18871
+component_owner: group:default/data-acquisition
 component_type: service
 description: Lightweight bluesky-as-a-service wrapper application. Also usable as
     a library.

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -27,7 +27,7 @@ metadata:
 spec:
   type: openapi
   lifecycle: production
-  owner: user:vid18871
+  owner: group:data-acquisition
   definition:
     $text: ./docs/reference/openapi.yaml
 ---
@@ -42,6 +42,6 @@ metadata:
 spec:
   type: asyncapi
   lifecycle: production
-  owner: user:vid18871
+  owner: group:data-acquisition
   definition:
     $text: ./docs/reference/asyncapi.yaml


### PR DESCRIPTION
Fixes #1090

### Instructions to reviewer on how to test:
1. I have checked that the core services like numtracker,blueapi,etc are currently under `data-acquisition` and not `core-data-acquisition`
2. Confirm If backstage `component-owner` is correct

### Checks for reviewer
- [ ] Would the PR title make sense to a user on a set of release notes
