### PR TITLE
fix: Mock second rest call in instrument session handling test

### DIFF
--- a/tests/unit_tests/test_cli.py
+++ b/tests/unit_tests/test_cli.py
@@ -434,11 +434,13 @@ def test_cannot_start_a_plan_without_an_instrument_session(runner: CliRunner):
     assert "Error: Missing option '-i' / '--instrument-session'.\n" in result.stderr
 
 
+@patch("blueapi.client.rest.BlueapiRestClient.update_worker_task")
 @patch("blueapi.client.rest.BlueapiRestClient.create_task")
 def test_can_pass_an_instrument_session_with_an_environment_variable(
-    mock_create_task: Mock, runner: CliRunner
+    mock_create_task: Mock, mock_update_worker_task: Mock, runner: CliRunner
 ):
     mock_create_task.return_value = TaskResponse(task_id="foo")
+    mock_update_worker_task.return_value = TaskResponse(task_id="foo")
     with patch.dict(
         os.environ,
         {"BLUEAPI_CONTROLLER_RUN_INSTRUMENT_SESSION": "cm12345-1"},
@@ -455,7 +457,7 @@ def test_can_pass_an_instrument_session_with_an_environment_variable(
                 '{"time": 5.0}',
             ],
         )
-    assert result.exit_code == 0
+    assert result.exit_code == 0, result.output
     mock_create_task.assert_called_once_with(
         TaskRequest(
             name="sleep",


### PR DESCRIPTION
Not sure why this isn't failing in CI so might be something odd with my setup locally but I currently get `KeyError("{'detail': 'Not Found'}"` when it tries to start the task.