### PR TITLE
fix!: Remove instrument_session from config

### DIFF
--- a/src/blueapi/config.py
+++ b/src/blueapi/config.py
@@ -80,7 +80,6 @@ class WorkerEventConfig(BlueapiBaseModel):
 
 
 class MetadataConfig(BlueapiBaseModel):
-    instrument_session: str
     instrument: str
 
 

--- a/src/blueapi/worker/task.py
+++ b/src/blueapi/worker/task.py
@@ -37,7 +37,8 @@ class Task(BlueapiBaseModel):
 
         func = ctx.plan_functions[self.name]
         prepared_params = self.prepare_params(ctx)
-        ctx.run_engine(func(**prepared_params), metadata_kw=self.metadata)
+        ctx.run_engine.md.update(self.metadata)
+        ctx.run_engine(func(**prepared_params))
 
 
 def _lookup_params(ctx: BlueskyContext, task: Task) -> BaseModel:

--- a/tests/unit_tests/core/test_context.py
+++ b/tests/unit_tests/core/test_context.py
@@ -356,11 +356,9 @@ def test_add_metadata_with_config(
     empty_context: BlueskyContext,
 ):
     empty_context.with_config(
-        EnvironmentConfig(
-            metadata=MetadataConfig(instrument="p46", instrument_session="ab123")
-        )
+        EnvironmentConfig(metadata=MetadataConfig(instrument="p46"))
     )
-    metadata = [("instrument", "p46"), ("instrument_session", "ab123")]
+    metadata = [("instrument", "p46")]
 
     for md in metadata:
         assert md in empty_context.run_engine.md.items()

--- a/tests/unit_tests/service/test_interface.py
+++ b/tests/unit_tests/service/test_interface.py
@@ -404,9 +404,7 @@ def test_configure_numtracker():
         numtracker=NumtrackerConfig(
             url=HttpUrl("https://numtracker-example.com/graphql")
         ),
-        env=EnvironmentConfig(
-            metadata=MetadataConfig(instrument="p46", instrument_session="ab123")
-        ),
+        env=EnvironmentConfig(metadata=MetadataConfig(instrument="p46")),
     )
     interface.set_config(conf)
     headers = {"a": "b"}
@@ -422,9 +420,7 @@ def test_configure_numtracker():
 
 def test_configure_numtracker_with_no_numtracker_config_fails():
     conf = ApplicationConfig(
-        env=EnvironmentConfig(
-            metadata=MetadataConfig(instrument="p46", instrument_session="ab123")
-        ),
+        env=EnvironmentConfig(metadata=MetadataConfig(instrument="p46")),
     )
     interface.set_config(conf)
     headers = {"a": "b"}
@@ -474,9 +470,7 @@ def test_setup_without_numtracker_without_existing_provider_does_not_make_one():
 
 def test_setup_with_numtracker_makes_start_document_provider():
     conf = ApplicationConfig(
-        env=EnvironmentConfig(
-            metadata=MetadataConfig(instrument="p46", instrument_session="ab123")
-        ),
+        env=EnvironmentConfig(metadata=MetadataConfig(instrument="p46")),
         numtracker=NumtrackerConfig(),
     )
     interface.setup(conf)
@@ -499,7 +493,7 @@ def test_setup_with_numtracker_raises_if_provider_is_defined_in_device_module():
                     module="tests.unit_tests.service.example_beamline_with_path_provider",
                 ),
             ],
-            metadata=MetadataConfig(instrument="p46", instrument_session="ab123"),
+            metadata=MetadataConfig(instrument="p46"),
         ),
         numtracker=NumtrackerConfig(),
     )
@@ -521,9 +515,7 @@ def test_numtracker_create_scan_called_with_arguments_from_metadata(mock_create_
         numtracker=NumtrackerConfig(
             url=HttpUrl("https://numtracker-example.com/graphql")
         ),
-        env=EnvironmentConfig(
-            metadata=MetadataConfig(instrument="p46", instrument_session="ab123")
-        ),
+        env=EnvironmentConfig(metadata=MetadataConfig(instrument="p46")),
     )
     interface.set_config(conf)
     ctx = interface.context()
@@ -531,6 +523,7 @@ def test_numtracker_create_scan_called_with_arguments_from_metadata(mock_create_
 
     headers = {"a": "b"}
     interface._try_configure_numtracker(headers)
+    ctx.run_engine.md["instrument_session"] = "ab123"
     interface._update_scan_num(ctx.run_engine.md)
 
     mock_create_scan.assert_called_once_with("ab123", "p46")
@@ -542,9 +535,7 @@ def test_update_scan_num_side_effect_sets_data_session_directory_in_re_md(
     mock_numtracker_server,
 ):
     conf = ApplicationConfig(
-        env=EnvironmentConfig(
-            metadata=MetadataConfig(instrument="p46", instrument_session="ab123")
-        ),
+        env=EnvironmentConfig(metadata=MetadataConfig(instrument="p46")),
         numtracker=NumtrackerConfig(
             url=HttpUrl("https://numtracker-example.com/graphql")
         ),
@@ -552,6 +543,7 @@ def test_update_scan_num_side_effect_sets_data_session_directory_in_re_md(
     interface.setup(conf)
     ctx = interface.context()
 
+    ctx.run_engine.md["instrument_session"] = "ab123"
     interface._update_scan_num(ctx.run_engine.md)
 
     assert (

--- a/tests/unit_tests/test_config.py
+++ b/tests/unit_tests/test_config.py
@@ -283,7 +283,6 @@ def test_config_yaml_parsed(temp_yaml_config_file):
                     "broadcast_status_events": True,
                 },
                 "metadata": {
-                    "instrument_session": "aa123456",
                     "instrument": "p01",
                 },
                 "sources": [
@@ -335,7 +334,6 @@ def test_config_yaml_parsed(temp_yaml_config_file):
                 ],
                 "events": {"broadcast_status_events": True},
                 "metadata": {
-                    "instrument_session": "aa123456",
                     "instrument": "p01",
                 },
             },
@@ -413,7 +411,6 @@ def test_config_yaml_parsed_complete(temp_yaml_config_file: dict):
                 ],
                 "events": {"broadcast_status_events": True},
                 "metadata": {
-                    "instrument_session": "aa123456",
                     "instrument": "p01",
                 },
             },

--- a/tests/unit_tests/worker/test_task_worker.py
+++ b/tests/unit_tests/worker/test_task_worker.py
@@ -326,14 +326,10 @@ def test_full_queue_raises_WorkerBusyError(put_nowait: MagicMock, worker: TaskWo
 
 def test_metadata_passed_to_context(context: BlueskyContext):
     context.run_engine = Mock()
+    context.run_engine.md = {}
     _TASK_WITH_METADATA.do_task(context)
-    context.run_engine.assert_called_once_with(
-        ANY,
-        metadata_kw={
-            "foo": "bar",
-            "baz": 0,
-        },
-    )
+    for metadata in [("foo", "bar"), ("baz", 0)]:
+        assert metadata in context.run_engine.md.items()
 
 
 #


### PR DESCRIPTION
Removes the instrument session from the config, which is no longer required as of 0.19.0 requiring the instrument_session being passed with the request as of #1062 

This is a breaking change as our Config classes do not allow additional fields. An alternative is to deprecate the field and default it to None, but as this is still pre-1.0.0 I thought it was easier to bundle this change in.