### PR TITLE
refactor(container): Split dev and debug requirements

### DIFF
--- a/.github/workflows/_container.yml
+++ b/.github/workflows/_container.yml
@@ -49,6 +49,7 @@ jobs:
         with:
           context: .
           # Need load and tags so we can test it below
+          target: runtime
           load: true
           tags: tag_for_testing
 
@@ -94,6 +95,7 @@ jobs:
         with:
           context: .
           push: true
+          target: runtime
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 

--- a/helm/blueapi/templates/statefulset.yaml
+++ b/helm/blueapi/templates/statefulset.yaml
@@ -91,6 +91,7 @@ spec:
             if [ $? -ne 0 ]; then echo 'Blueapi failed'; exit 1; fi;
             echo "Exporting venv as artefact"
             cp -r /venv/* /artefacts
+            {{if .Values.initContainer.persistentVolume.enabled }}chmod o+wrX -R {{ .Values.worker.scratch.root }}{{- end}}
         volumeMounts:
           - name: init-config
             mountPath: "/config"


### PR DESCRIPTION
Refactors the container build so that the non-debug image can be used to debug traces outside of the cluster using `kubectl exec` and `kubectl port-forward`, and allow editing when using `pv-mounter` to mount the scratch dir locally.

This allows for seperate `debug` and `development` workflows: when debugging plans, the debugger can be used to step through and examine variables in the namespace, and when developing local tooling can be used. 

The devcontainer attach workflow is for now preserved, and `-debug` tag to mark an image as allow debugging of the service itself, separate from the ability to debug the plans and devices.
