### PR TITLE
ci: Add Gitleaks pre-commit hook for detecting potential credentials

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,3 +31,8 @@ repos:
         args:
           # Make the tool search for charts only under the `helm` directory
           - --chart-search-root=helm
+
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.28.0
+    hooks:
+      - id: gitleaks


### PR DESCRIPTION
### Instructions to reviewer on how to test:
1. Pull this branch and verify that `pre-commit` hooks are active.
   Run the following command to confirm `gitleaks` is correctly set up:

   ```
   pre-commit run --all-files
   ```

   This should include output from gitleaks, detecting potential hardcoded secrets.
   
   Note: It is assumed that the CI environment handles installing gitleaks as part of the `pre-commit` configuration.
   For local testing, the following setup was used:

   ```
   python3 -m venv .venv
   source .venv/bin/activate
   pip install pre-commit
   pre-commit install --hook-type pre-commit
   pre-commit run --all-files
   ```

2.  Test gitleaks manually by attempting to commit a file containing a fake secret (e.g., a fake API key or private key).
   The commit should be blocked by gitleaks if the secret is detected. Note that detection may include false positives or occasionally miss some secrets (false negatives). 

    For more information, including configuration options for customizing detection rules, refer to the official documentation:
    https://github.com/gitleaks/gitleaks


