### PR TITLE
feat: Add logout redirect

### DIFF
--- a/docs/how-to/authenticate.md
+++ b/docs/how-to/authenticate.md
@@ -1,4 +1,8 @@
-# Authenticate to BlueAPI
+> [!NOTE]
+> If you are using `oauth2-proxy` to secure the Swagger UI documentation page, you can log out by visiting the `/logout` URL. For this to work correctly, ensure that the blueapi server is configured with 
+> `oidc.logout_redirect_endpoint` set to `/oauth2/sign_out`, which is required for `oauth2-proxy`.
+
+# Authenticate to BlueAPI-Cli
 
 ## Introduction
 BlueAPI provides a secure and efficient way to interact with its services. This guide walks you through the steps to log in and log out using BlueAPI with OpenID Connect (OIDC) authentication.
@@ -63,9 +67,3 @@ To log out and securely remove the cached access token, follow these steps:
    ```
    Logged out
    ```
-
-
-> [!NOTE]
-> The login and logout instructions above apply to the CLI. If you are using `oauth2-proxy` to secure the Swagger
-> UI documentation page, you can log out by visiting the `/logout` URL. For other OIDC providers, update the 
-> `oidc.logout_redirect_endpoint` configuration to the appropriate logout endpoint.

--- a/docs/how-to/authenticate.md
+++ b/docs/how-to/authenticate.md
@@ -63,3 +63,9 @@ To log out and securely remove the cached access token, follow these steps:
    ```
    Logged out
    ```
+
+
+> [!NOTE]
+> The login and logout instructions above apply to the CLI. If you are using `oauth2-proxy` to secure the Swagger
+> UI documentation page, you can log out by visiting the `/logout` URL. For other OIDC providers, update the 
+> `oidc.logout_redirect_endpoint` configuration to the appropriate logout endpoint.

--- a/docs/reference/openapi.yaml
+++ b/docs/reference/openapi.yaml
@@ -355,7 +355,7 @@ info:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
   title: BlueAPI Control
-  version: 1.0.3
+  version: 1.1.0
 openapi: 3.1.0
 paths:
   /config/oidc:

--- a/docs/reference/openapi.yaml
+++ b/docs/reference/openapi.yaml
@@ -93,6 +93,7 @@ components:
           title: Client Id
           type: string
         logout_redirect_endpoint:
+          default: ''
           description: The oidc endpoint required to logout
           title: Logout Redirect Endpoint
           type: string

--- a/docs/reference/openapi.yaml
+++ b/docs/reference/openapi.yaml
@@ -92,6 +92,11 @@ components:
           description: Client ID
           title: Client Id
           type: string
+        logout_redirect_endpoint:
+          default: /oauth2/sign_out
+          description: The oidc endpoint required to logout
+          title: Logout Redirect Endpoint
+          type: string
         well_known_url:
           description: URL to fetch OIDC config from the provider
           title: Well Known Url
@@ -350,7 +355,7 @@ info:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
   title: BlueAPI Control
-  version: 1.0.2
+  version: 1.0.3
 openapi: 3.1.0
 paths:
   /config/oidc:

--- a/docs/reference/openapi.yaml
+++ b/docs/reference/openapi.yaml
@@ -93,10 +93,11 @@ components:
           title: Client Id
           type: string
         logout_redirect_endpoint:
-          default: /oauth2/sign_out
+          anyOf:
+          - type: string
+          - type: 'null'
           description: The oidc endpoint required to logout
           title: Logout Redirect Endpoint
-          type: string
         well_known_url:
           description: URL to fetch OIDC config from the provider
           title: Well Known Url

--- a/docs/reference/openapi.yaml
+++ b/docs/reference/openapi.yaml
@@ -93,11 +93,9 @@ components:
           title: Client Id
           type: string
         logout_redirect_endpoint:
-          anyOf:
-          - type: string
-          - type: 'null'
           description: The oidc endpoint required to logout
           title: Logout Redirect Endpoint
+          type: string
         well_known_url:
           description: URL to fetch OIDC config from the provider
           title: Well Known Url

--- a/helm/blueapi/config_schema.json
+++ b/helm/blueapi/config_schema.json
@@ -196,6 +196,12 @@
                     "description": "Client Audience(s)",
                     "title": "Client Audience",
                     "type": "string"
+                },
+                "logout_redirect_endpoint": {
+                    "default": null,
+                    "description": "The oidc endpoint required to logout",
+                    "title": "Logout Redirect Endpoint",
+                    "type": "string"
                 }
             },
             "required": [

--- a/helm/blueapi/config_schema.json
+++ b/helm/blueapi/config_schema.json
@@ -198,7 +198,7 @@
                     "type": "string"
                 },
                 "logout_redirect_endpoint": {
-                    "default": null,
+                    "default": "",
                     "description": "The oidc endpoint required to logout",
                     "title": "Logout Redirect Endpoint",
                     "type": "string"

--- a/helm/blueapi/values.schema.json
+++ b/helm/blueapi/values.schema.json
@@ -676,6 +676,11 @@
                             "description": "Client ID",
                             "type": "string"
                         },
+                        "logout_redirect_endpoint": {
+                            "title": "Logout Redirect Endpoint",
+                            "description": "The oidc endpoint required to logout",
+                            "type": "string"
+                        },
                         "well_known_url": {
                             "title": "Well Known Url",
                             "description": "URL to fetch OIDC config from the provider",

--- a/helm/blueapi/values.schema.json
+++ b/helm/blueapi/values.schema.json
@@ -679,7 +679,14 @@
                         "logout_redirect_endpoint": {
                             "title": "Logout Redirect Endpoint",
                             "description": "The oidc endpoint required to logout",
-                            "type": "string"
+                            "anyOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ]
                         },
                         "well_known_url": {
                             "title": "Well Known Url",

--- a/helm/blueapi/values.schema.json
+++ b/helm/blueapi/values.schema.json
@@ -679,14 +679,8 @@
                         "logout_redirect_endpoint": {
                             "title": "Logout Redirect Endpoint",
                             "description": "The oidc endpoint required to logout",
-                            "anyOf": [
-                                {
-                                    "type": "string"
-                                },
-                                {
-                                    "type": "null"
-                                }
-                            ]
+                            "default": "",
+                            "type": "string"
                         },
                         "well_known_url": {
                             "title": "Well Known Url",

--- a/src/blueapi/config.py
+++ b/src/blueapi/config.py
@@ -162,6 +162,9 @@ class OIDCConfig(BlueapiBaseModel):
     )
     client_id: str = Field(description="Client ID")
     client_audience: str = Field(description="Client Audience(s)", default="blueapi")
+    logout_redirect_endpoint: str = Field(
+        description="The oidc endpoint required to logout", default="/oauth2/sign_out"
+    )
 
     @cached_property
     def _config_from_oidc_url(self) -> dict[str, Any]:

--- a/src/blueapi/config.py
+++ b/src/blueapi/config.py
@@ -162,8 +162,8 @@ class OIDCConfig(BlueapiBaseModel):
     )
     client_id: str = Field(description="Client ID")
     client_audience: str = Field(description="Client Audience(s)", default="blueapi")
-    logout_redirect_endpoint: str = Field(
-        description="The oidc endpoint required to logout", default="/oauth2/sign_out"
+    logout_redirect_endpoint: str | None = Field(
+        description="The oidc endpoint required to logout", default=None
     )
 
     @cached_property

--- a/src/blueapi/config.py
+++ b/src/blueapi/config.py
@@ -21,6 +21,7 @@ from pydantic import (
     ValidationError,
     field_validator,
 )
+from pydantic.json_schema import SkipJsonSchema
 
 from blueapi.utils import BlueapiBaseModel, InvalidConfigError
 
@@ -162,7 +163,7 @@ class OIDCConfig(BlueapiBaseModel):
     )
     client_id: str = Field(description="Client ID")
     client_audience: str = Field(description="Client Audience(s)", default="blueapi")
-    logout_redirect_endpoint: str | None = Field(
+    logout_redirect_endpoint: str | SkipJsonSchema[None] = Field(
         description="The oidc endpoint required to logout", default=None
     )
 

--- a/src/blueapi/config.py
+++ b/src/blueapi/config.py
@@ -21,7 +21,6 @@ from pydantic import (
     ValidationError,
     field_validator,
 )
-from pydantic.json_schema import SkipJsonSchema
 
 from blueapi.utils import BlueapiBaseModel, InvalidConfigError
 
@@ -167,8 +166,8 @@ class OIDCConfig(BlueapiBaseModel):
     )
     client_id: str = Field(description="Client ID")
     client_audience: str = Field(description="Client Audience(s)", default="blueapi")
-    logout_redirect_endpoint: str | SkipJsonSchema[None] = Field(
-        description="The oidc endpoint required to logout", default=None
+    logout_redirect_endpoint: str = Field(
+        description="The oidc endpoint required to logout", default=""
     )
 
     @cached_property

--- a/src/blueapi/service/main.py
+++ b/src/blueapi/service/main.py
@@ -57,7 +57,7 @@ from .model import (
 from .runner import WorkerDispatcher
 
 #: API version to publish in OpenAPI schema
-REST_API_VERSION = "1.0.3"
+REST_API_VERSION = "1.1.0"
 
 LICENSE_INFO: dict[str, str] = {
     "name": "Apache 2.0",
@@ -535,7 +535,7 @@ def health_probe() -> HealthProbeResponse:
     return HealthProbeResponse(status=Health.OK)
 
 
-@secure_router.get("/logout", status_code=status.HTTP_200_OK, include_in_schema=False)
+@secure_router.get("/logout", include_in_schema=False)
 def logout(runner: Annotated[WorkerDispatcher, Depends(_runner)]) -> RedirectResponse:
     """Redirect to logout url"""
     config = runner.run(interface.get_oidc_config)

--- a/src/blueapi/service/main.py
+++ b/src/blueapi/service/main.py
@@ -17,6 +17,7 @@ from fastapi import (
     status,
 )
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import RedirectResponse
 from fastapi.security import OAuth2AuthorizationCodeBearer
 from observability_utils.tracing import (
     add_span_attributes,
@@ -532,6 +533,18 @@ def get_python_environment(
 def health_probe() -> HealthProbeResponse:
     """If able to serve this, server is live and ready for requests."""
     return HealthProbeResponse(status=Health.OK)
+
+
+@secure_router.get("/logout", status_code=status.HTTP_200_OK, include_in_schema=False)
+def logout(runner: Annotated[WorkerDispatcher, Depends(_runner)]) -> RedirectResponse:
+    """Redirect to logout url"""
+    config = runner.run(interface.get_oidc_config)
+    if config is None:
+        raise HTTPException(status_code=status.HTTP_204_NO_CONTENT)
+    return RedirectResponse(
+        url=config.logout_redirect_endpoint,
+        headers={"X-Auth-Request-Redirect": config.end_session_endpoint},
+    )
 
 
 @start_as_current_span(TRACER, "config")

--- a/src/blueapi/service/main.py
+++ b/src/blueapi/service/main.py
@@ -542,6 +542,7 @@ def logout(runner: Annotated[WorkerDispatcher, Depends(_runner)]) -> RedirectRes
     if config is None:
         raise HTTPException(status_code=status.HTTP_204_NO_CONTENT)
     return RedirectResponse(
+        status_code=status.HTTP_308_PERMANENT_REDIRECT,
         url=config.logout_redirect_endpoint,
         headers={"X-Auth-Request-Redirect": config.end_session_endpoint},
     )

--- a/src/blueapi/service/main.py
+++ b/src/blueapi/service/main.py
@@ -57,7 +57,7 @@ from .model import (
 from .runner import WorkerDispatcher
 
 #: API version to publish in OpenAPI schema
-REST_API_VERSION = "1.0.2"
+REST_API_VERSION = "1.0.3"
 
 LICENSE_INFO: dict[str, str] = {
     "name": "Apache 2.0",

--- a/src/blueapi/service/main.py
+++ b/src/blueapi/service/main.py
@@ -539,7 +539,7 @@ def health_probe() -> HealthProbeResponse:
 def logout(runner: Annotated[WorkerDispatcher, Depends(_runner)]) -> Response:
     """Redirect to logout url"""
     config = runner.run(interface.get_oidc_config)
-    if config is None or config.logout_redirect_endpoint is None:
+    if config is None or not config.logout_redirect_endpoint:
         raise HTTPException(status_code=status.HTTP_205_RESET_CONTENT)
     return RedirectResponse(
         status_code=status.HTTP_308_PERMANENT_REDIRECT,

--- a/src/blueapi/service/main.py
+++ b/src/blueapi/service/main.py
@@ -536,11 +536,11 @@ def health_probe() -> HealthProbeResponse:
 
 
 @secure_router.get("/logout", include_in_schema=False)
-def logout(runner: Annotated[WorkerDispatcher, Depends(_runner)]) -> RedirectResponse:
+def logout(runner: Annotated[WorkerDispatcher, Depends(_runner)]) -> Response:
     """Redirect to logout url"""
     config = runner.run(interface.get_oidc_config)
-    if config is None:
-        raise HTTPException(status_code=status.HTTP_204_NO_CONTENT)
+    if config is None or config.logout_redirect_endpoint is None:
+        raise HTTPException(status_code=status.HTTP_205_RESET_CONTENT)
     return RedirectResponse(
         status_code=status.HTTP_308_PERMANENT_REDIRECT,
         url=config.logout_redirect_endpoint,

--- a/tests/unit_tests/service/test_rest_api.py
+++ b/tests/unit_tests/service/test_rest_api.py
@@ -773,7 +773,7 @@ def test_logout_when_oidc_config_invalid(
     client_authenticated: TestClient,
 ):
     if has_oidc_config:
-        oidc_config.logout_redirect_endpoint = None
+        oidc_config.logout_redirect_endpoint = ""
         mock_runner.run.return_value = oidc_config
     else:
         mock_runner.run.return_value = None

--- a/tests/unit_tests/test_config.py
+++ b/tests/unit_tests/test_config.py
@@ -312,7 +312,7 @@ def test_config_yaml_parsed(temp_yaml_config_file):
                 "well_known_url": "https://auth.example.com/realms/sample/.well-known/openid-configuration",
                 "client_id": "blueapi-client",
                 "client_audience": "aud",
-                "logout_redirect_endpoint": None,
+                "logout_redirect_endpoint": "",
             },
             "scratch": {
                 "root": "/tmp/scratch/blueapi",
@@ -359,7 +359,7 @@ def test_config_yaml_parsed(temp_yaml_config_file):
                 "well_known_url": "https://auth.example.com/realms/sample/.well-known/openid-configuration",
                 "client_id": "blueapi-client",
                 "client_audience": "aud",
-                "logout_redirect_endpoint": None,
+                "logout_redirect_endpoint": "",
             },
             "scratch": {
                 "root": "/tmp/scratch/blueapi",

--- a/tests/unit_tests/test_config.py
+++ b/tests/unit_tests/test_config.py
@@ -307,6 +307,7 @@ def test_config_yaml_parsed(temp_yaml_config_file):
                 "well_known_url": "https://auth.example.com/realms/sample/.well-known/openid-configuration",
                 "client_id": "blueapi-client",
                 "client_audience": "aud",
+                "logout_redirect_endpoint": "/oauth2/sign_out",
             },
             "scratch": {
                 "root": "/tmp/scratch/blueapi",
@@ -353,6 +354,7 @@ def test_config_yaml_parsed(temp_yaml_config_file):
                 "well_known_url": "https://auth.example.com/realms/sample/.well-known/openid-configuration",
                 "client_id": "blueapi-client",
                 "client_audience": "aud",
+                "logout_redirect_endpoint": "/oauth2/sign_out",
             },
             "scratch": {
                 "root": "/tmp/scratch/blueapi",

--- a/tests/unit_tests/test_config.py
+++ b/tests/unit_tests/test_config.py
@@ -307,7 +307,7 @@ def test_config_yaml_parsed(temp_yaml_config_file):
                 "well_known_url": "https://auth.example.com/realms/sample/.well-known/openid-configuration",
                 "client_id": "blueapi-client",
                 "client_audience": "aud",
-                "logout_redirect_endpoint": "/oauth2/sign_out",
+                "logout_redirect_endpoint": None,
             },
             "scratch": {
                 "root": "/tmp/scratch/blueapi",
@@ -354,7 +354,7 @@ def test_config_yaml_parsed(temp_yaml_config_file):
                 "well_known_url": "https://auth.example.com/realms/sample/.well-known/openid-configuration",
                 "client_id": "blueapi-client",
                 "client_audience": "aud",
-                "logout_redirect_endpoint": "/oauth2/sign_out",
+                "logout_redirect_endpoint": None,
             },
             "scratch": {
                 "root": "/tmp/scratch/blueapi",


### PR DESCRIPTION
Currently we can logout by going to this https://p46-blueapi.diamond.ac.uk/oauth2/sign_out?rd=https%3A%2F%2Fauthn.diamond.ac.uk%2Frealms%2Fmaster%2Fprotocol%2Fopenid-connect%2Flogout. It will be much simpler to logout by going to https://p46-blueapi.diamond.ac.uk/logout. This is when we have oauth2-proxy enabled for blueapi docs page