### PR TITLE
fix: Use alternative logout url for oauth2

### DIFF
--- a/src/blueapi/service/main.py
+++ b/src/blueapi/service/main.py
@@ -546,7 +546,7 @@ def logout(runner: Annotated[WorkerDispatcher, Depends(_runner)]) -> Response:
     encoded_url = urllib.parse.quote_plus(config.end_session_endpoint)
     return RedirectResponse(
         status_code=status.HTTP_308_PERMANENT_REDIRECT,
-        url=urllib.parse.urljoin(config.logout_redirect_endpoint, encoded_url),
+        url=config.logout_redirect_endpoint.rstrip("/") + "?rd=" + encoded_url,
     )
 
 

--- a/src/blueapi/service/main.py
+++ b/src/blueapi/service/main.py
@@ -1,4 +1,5 @@
 import logging
+import urllib.parse
 from collections.abc import Awaitable, Callable
 from contextlib import asynccontextmanager
 from enum import Enum
@@ -541,10 +542,11 @@ def logout(runner: Annotated[WorkerDispatcher, Depends(_runner)]) -> Response:
     config = runner.run(interface.get_oidc_config)
     if config is None or not config.logout_redirect_endpoint:
         raise HTTPException(status_code=status.HTTP_205_RESET_CONTENT)
+
+    encoded_url = urllib.parse.quote_plus(config.end_session_endpoint)
     return RedirectResponse(
         status_code=status.HTTP_308_PERMANENT_REDIRECT,
-        url=config.logout_redirect_endpoint,
-        headers={"X-Auth-Request-Redirect": config.end_session_endpoint},
+        url=urllib.parse.urljoin(config.logout_redirect_endpoint, encoded_url),
     )
 
 

--- a/tests/unit_tests/service/test_rest_api.py
+++ b/tests/unit_tests/service/test_rest_api.py
@@ -734,14 +734,14 @@ def test_logout(
     oidc_config: OIDCConfig,
     client_with_auth: TestClient,
 ):
-    oidc_config.logout_redirect_endpoint = "/oauth2/logout/"
+    oidc_config.logout_redirect_endpoint = "/oauth2/sign_out/"
     mock_runner.run.return_value = oidc_config
     client_with_auth.follow_redirects = False
     response = client_with_auth.get("/logout")
     assert response.status_code == status.HTTP_308_PERMANENT_REDIRECT
     assert (
         response.headers.get("location")
-        == "/oauth2/logout/https%3A%2F%2Fexample.com%2Fend_session"
+        == "/oauth2/sign_out?rd=https%3A%2F%2Fexample.com%2Fend_session"
     )
 
 

--- a/tests/unit_tests/service/test_rest_api.py
+++ b/tests/unit_tests/service/test_rest_api.py
@@ -734,16 +734,15 @@ def test_logout(
     oidc_config: OIDCConfig,
     client_with_auth: TestClient,
 ):
-    oidc_config.logout_redirect_endpoint = "/oauth2/logout"
+    oidc_config.logout_redirect_endpoint = "/oauth2/logout/"
     mock_runner.run.return_value = oidc_config
     client_with_auth.follow_redirects = False
     response = client_with_auth.get("/logout")
     assert response.status_code == status.HTTP_308_PERMANENT_REDIRECT
     assert (
-        response.headers.get("X-Auth-Request-Redirect")
-        == oidc_config.end_session_endpoint
+        response.headers.get("location")
+        == "/oauth2/logout/https%3A%2F%2Fexample.com%2Fend_session"
     )
-    assert response.headers.get("location") == oidc_config.logout_redirect_endpoint
 
 
 @pytest.mark.parametrize("has_oidc_config", [True, False])


### PR DESCRIPTION
Currently it is sending the request to the oauth2-proxy but is not redirecting blueapi to the Identity provider so I will give this a try with the  other method in oauth2-proxy docs.

```
[2025/08/27 10:20:01] p46-blueapi.diamond.ac.uk GET blueapi "/logout" HTTP/1.1 "Mozilla/5.0 (X11; Linux x86_64; rv:142.0) Gecko/20100101 Firefox/142.0" 308 0 0.008
10.32.0.21:57828 - 6cc428867cd7ff0b3ddc0faabc4cddcf - b1370833-c4a3-49c2-9a1e-1a69e3854b59 [2025/08/27 10:20:01] p46-blueapi.diamond.ac.uk GET - "/oauth2/sign_out" HTTP/1.1 "Mozilla/5.0 (X11; Linux x86_64; rv:142.0) Gecko/20100101 Firefox/142.0" 302 24 0.000
```