### PR TITLE
docs: Remove example stomp config

### DIFF
--- a/docs/tutorials/run-bus.md
+++ b/docs/tutorials/run-bus.md
@@ -26,4 +26,3 @@ blueapi --config /path/to/stomp.yaml serve
 ```
 
 The server should print a connection message to the console. If there is an error, it will print an error message instead.
-When checking out the repository, there is an example STOMP config present in `src/script/stomp_config.yml`

--- a/src/script/stomp_config.yml
+++ b/src/script/stomp_config.yml
@@ -1,7 +1,0 @@
----
-stomp:
-  host: "localhost"
-  port: 61613
-  auth:
-    username: "guest"
-    password: "guest"


### PR DESCRIPTION
Config was no longer valid and is no longer needed to launch local
rabbitMQ instance.
