### PR TITLE
Add graypy dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "observability-utils>=0.1.4",
     "pyjwt[crypto]",
     "tomlkit",
+    "graypy>=2.1.0",
 ]
 dynamic = ["version"]
 license.file = "LICENSE"


### PR DESCRIPTION
This is depended on directly in the log module but was only
provided as a transitive dependency via dodal.
