### PR TITLE
fix: Ensure that numtracker headers are not re-used

### DIFF
--- a/src/blueapi/service/interface.py
+++ b/src/blueapi/service/interface.py
@@ -224,8 +224,7 @@ def begin_task(
     task: WorkerTask, pass_through_headers: Mapping[str, str] | None = None
 ) -> WorkerTask:
     """Trigger a task. Will fail if the worker is busy"""
-    if pass_through_headers:
-        _try_configure_numtracker(pass_through_headers)
+    _try_configure_numtracker(pass_through_headers or {})
 
     if task.task_id is not None:
         worker().begin_task(task.task_id)


### PR DESCRIPTION
If the headers are only set when they are present but not cleared at the
end of a plan (or when they're absent), a request with no headers
following a request with headers will re-use the previous users
credentials allowing unauthenticated access to running plans.

Setting the headers to an empty map if none are present helps ensure
tokens cannot be used by other users.


Fixes: #1201 