### PR TITLE
fix: Prevent spans being swallowed by infinite startup span

### DIFF
--- a/src/blueapi/service/runner.py
+++ b/src/blueapi/service/runner.py
@@ -109,7 +109,6 @@ class WorkerDispatcher:
                 error_message=_safe_exception_message(e),
             )
 
-    @start_as_current_span(TRACER, "function", "args", "kwargs")
     def run(
         self,
         function: Callable[P, T],

--- a/src/blueapi/service/runner.py
+++ b/src/blueapi/service/runner.py
@@ -71,7 +71,6 @@ class WorkerDispatcher:
         self.start()
         LOGGER.info("Runner reloaded")
 
-    @start_as_current_span(TRACER)
     def start(self):
         environment_id = uuid.uuid4()
         try:

--- a/src/blueapi/worker/task_worker.py
+++ b/src/blueapi/worker/task_worker.py
@@ -378,7 +378,6 @@ class TaskWorker:
         """
         return self._state
 
-    @start_as_current_span(TRACER)
     def run(self) -> None:
         """
         Run all tasks that are submitted to the worker. Blocks thread.

--- a/tests/unit_tests/service/test_runner.py
+++ b/tests/unit_tests/service/test_runner.py
@@ -5,10 +5,6 @@ from typing import Any, Generic, TypeVar
 from unittest.mock import MagicMock, Mock, NonCallableMock, patch
 
 import pytest
-from observability_utils.tracing import (
-    JsonObjectSpanExporter,
-    asserting_span_exporter,
-)
 from pydantic import BaseModel, ValidationError
 
 from blueapi.service import interface
@@ -293,10 +289,3 @@ def test_accepts_return_type(
     rpc_function: Callable[[], Any],
 ):
     started_runner.run(rpc_function)
-
-
-def test_run_span_ok(
-    exporter: JsonObjectSpanExporter, started_runner: WorkerDispatcher
-):
-    with asserting_span_exporter(exporter, "run", "function", "args", "kwargs"):
-        started_runner.run(interface.get_plans)


### PR DESCRIPTION
Fixes #1243 

Removes the spans for two methods that start either start subprocesses or loop infinitely, meaning the methods that they call can be displayed as unique traces rather than being swallowed into a single trace. 