### PR TITLE
fix: Prevent duplicate logging messages

### DIFF
--- a/src/blueapi/service/main.py
+++ b/src/blueapi/service/main.py
@@ -573,7 +573,9 @@ def start(config: ApplicationConfig):
     app.state.config = config
     assert config.api.url.host is not None, "API URL missing host"
     assert config.api.url.port is not None, "API URL missing port"
-    uvicorn.run(app, host=config.api.url.host, port=config.api.url.port)
+    uvicorn.run(
+        app, host=config.api.url.host, port=config.api.url.port, access_log=False
+    )
 
 
 async def add_api_version_header(


### PR DESCRIPTION
Fixes #1191 which had a regression: disables the uvicorn access_log logging, which logs all incoming and requests at the INFO level- instead our injected `log_request_details` logs healthz probes at DEBUG and all other endpoints at INFO. Previously we were also logging all endpoints twice, once with our middleware and once with the access probe.