### PR TITLE
fix: Make the path provider stack start docs

### DIFF
--- a/src/blueapi/utils/path_provider.py
+++ b/src/blueapi/utils/path_provider.py
@@ -29,7 +29,7 @@ class StartDocumentPathProvider(PathProvider):
                 self._docs.pop()
             else:
                 raise BlueskyRunStructureError(
-                    "Close run called, but not for the inner most run."
+                    "Close run called, but not for the inner most run. "
                     "This is not supported. If you need to do this speak to core DAQ."
                 )
 

--- a/tests/unit_tests/utils/test_path_provider.py
+++ b/tests/unit_tests/utils/test_path_provider.py
@@ -374,7 +374,7 @@ def test_start_document_path_provider_run_stop_called_out_of_order_raises(
 
     with pytest.raises(
         BlueskyRunStructureError,
-        match="Close run called, but not for the inner most run."
+        match="Close run called, but not for the inner most run. "
         "This is not supported. If you need to do this speak to core DAQ.",
     ):
         pp.run_stop(name="stop", stop_document=stop_doc_1)


### PR DESCRIPTION
Makes the `StartDocumentPathProvider` stack docs, using the latest for path determination.