### PR TITLE
fix: Support multiple blueapi instances in a namespace #1262

### DIFF
--- a/helm/blueapi/templates/statefulset.yaml
+++ b/helm/blueapi/templates/statefulset.yaml
@@ -60,7 +60,11 @@ spec:
       {{- if .Values.initContainer.persistentVolume.enabled }}
       - name: scratch
         persistentVolumeClaim:
-          claimName: {{default (tpl "scratch-{{ .Values.image.tag | default .Chart.AppVersion }}" .) .Values.initContainer.persistentVolume.existingClaimName }}
+          {{- if .Values.initContainer.persistentVolume.existingClaimName }}
+          claimName: {{ .Values.initContainer.persistentVolume.existingClaimName }}
+          {{- else }}
+          claimName: {{ include "blueapi.fullname" . }}-scratch-{{ .Values.image.tag | default .Chart.AppVersion }}
+          {{- end }}
       {{- else }}
       - name: scratch-host
         hostPath:

--- a/helm/blueapi/templates/volumes.yaml
+++ b/helm/blueapi/templates/volumes.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: scratch-{{ .Values.image.tag | default .Chart.AppVersion }}
+  name: {{ include "blueapi.fullname" . }}-scratch-{{ .Values.image.tag | default .Chart.AppVersion }}
   annotations:
     helm.sh/resource-policy: keep
 spec:

--- a/tests/unit_tests/test_helm_chart.py
+++ b/tests/unit_tests/test_helm_chart.py
@@ -593,11 +593,11 @@ def test_persistent_volume_claim_exists(
     )
 
     persistent_volume_claim = {
-        "scratch-0.1.0": {
+        "blueapi-scratch-0.1.0": {
             "apiVersion": "v1",
             "kind": "PersistentVolumeClaim",
             "metadata": {
-                "name": "scratch-0.1.0",
+                "name": "blueapi-scratch-0.1.0",
                 "annotations": {"helm.sh/resource-policy": "keep"},
             },
             "spec": {
@@ -836,7 +836,7 @@ def test_scratch_volume_uses_correct_name(
         assert claim_name == existing_claim_name
         assert "PersistentVolumeClaim" not in manifests
     else:
-        assert claim_name == "scratch-0.1.0"
+        assert claim_name == "blueapi-scratch-0.1.0"
         assert claim_name in manifests["PersistentVolumeClaim"]
 
 


### PR DESCRIPTION
Make persistent volume claims unique for each instance by prefixing each scratch name with blueapi.fullname helper.