### PR TITLE
chore(deps): Update dependencies

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -161,7 +161,7 @@ pyepics==3.5.8
 Pygments==2.19.2
 PyJWT==2.10.1
 pyparsing==3.2.5
-pyright==1.1.407
+pyright==1.1.406
 pytest==8.4.2
 pytest-asyncio==1.2.0
 pytest-cov==7.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dev = [
     "pre-commit>=3.8.0",
     "pydata-sphinx-theme>=0.15.4",
     "pytest",
-    "pyright",
+    "pyright<1.1.407",  # https://github.com/bluesky/scanspec/issues/190
     "pytest-cov",
     "pytest-asyncio",
     "responses",


### PR DESCRIPTION
Update dependencies for container build and devcontainer.
In particular, I need to pick up pvxslibs 1.4.1 due to [an issue with domain name resolution when using an EPICS gateway](https://github.com/epics-base/p4p/issues/188).
This also picks up [starlette>=0.49.1](https://github.com/DiamondLightSource/blueapi/security/dependabot/26), preventing a potential vulnerability that is not currently exposed due to no FileResponse usage. 

And also pins Pyright <1.1.407 due to [incompatibility with ScanSpec](https://github.com/bluesky/scanspec/issues/190)