### PR TITLE
fix: Correct oder and format of symlink creation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,7 @@ ENV MPLCONFIGDIR=/tmp/matplotlib
 # Make a path to site-packages that is invariant with python version
 # This allows our pathMapping in launch.jsons to always find build blueapi
 WORKDIR /venv/lib
-RUN ln -s python python${PYTHON_VERSION}
+RUN ln -sf python* python
 
 RUN groupadd -g 1000 blueapi && \
     useradd -m -u 1000 -g blueapi blueapi


### PR DESCRIPTION
TODO: build the Dockerfile and check that the symlink exists and is navigable.

This symlink will allow for our workspace pathMapping to always be correct when we update the version of python.