### PR TITLE
fix: Add security context to init container

### DIFF
--- a/helm/blueapi/templates/statefulset.yaml
+++ b/helm/blueapi/templates/statefulset.yaml
@@ -83,6 +83,10 @@ spec:
       {{- if .Values.initContainer.enabled }}
       initContainers:
       - name: setup-scratch
+        {{- with .Values.securityContext }}
+        securityContext:
+          {{- toYaml . | nindent 12 }}
+        {{- end }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         resources:


### PR DESCRIPTION
Add security context to init containe.

Recently when updating P4X to v1.11.2 the following error is produced by the init-container: `error: failed to create directory /.cache/uv: Permission denied (os error 13)` (I no longer have access to the full stack trace.)

Best guess is that UV attempts to cache at `($HOME)/.cache/uv` where `$HOME` is not set due to the user not "existing". By defining a security context we force the init container to use a specific UID (by default `1000`) which should have a real home dir.