### PR TITLE
fix: Handle errors from event stream callbacks

### DIFF
--- a/src/blueapi/core/event.py
+++ b/src/blueapi/core/event.py
@@ -78,12 +78,11 @@ class EventPublisher(EventStream[E, int]):
             correlation_id: An optional ID that may be used to correlate this
                 event with other events
         """
-
+        errs = []
         for callback in list(self._subscriptions.values()):
             try:
                 callback(event, correlation_id)
             except Exception as e:
-                LOGGER.error(
-                    f"Failed to send event {event} with {correlation_id=}",
-                    exc_info=e,
-                )
+                errs.append(e)
+        if errs:
+            raise ExceptionGroup(f"Error(s) publishing event: {event}", errs)

--- a/tests/unit_tests/core/test_event.py
+++ b/tests/unit_tests/core/test_event.py
@@ -86,9 +86,10 @@ def test_callback_exceptions_are_contained(publisher: EventPublisher[MyEvent]):
     publisher.subscribe(handler)
     publisher.subscribe(handler)
 
-    publisher.publish(event, c_id)
+    with pytest.RaisesGroup(ValueError):
+        publisher.publish(event, c_id)
 
-    # Both handlers should be called and the exception should not be raised from publish
+    # Both handlers should be called but the exception should still be raised
     handler.assert_has_calls([mock.call(event, c_id), mock.call(event, c_id)])
 
 


### PR DESCRIPTION
If a callback raises an exception, it shouldn't prevent other callbacks
receiving the same event. Instead, catch any exceptions and re-raise
them after all callbacks have been called as a single ExceptionGroup.
This allows the task to be aborted if any of the callbacks fail but
still allows callbacks that require the "plan failed" events to run.

