### PR TITLE
fix: Use find_device from device endpoint

### DIFF
--- a/src/blueapi/service/interface.py
+++ b/src/blueapi/service/interface.py
@@ -141,7 +141,10 @@ def get_devices() -> list[DeviceModel]:
 
 def get_device(name: str) -> DeviceModel:
     """Retrieve device by name from the BlueskyContext"""
-    return DeviceModel.from_device(context().devices[name])
+    if not (device := context().find_device(name)):
+        raise KeyError(name)
+
+    return DeviceModel.from_device(device)
 
 
 def submit_task(task_request: TaskRequest) -> str:


### PR DESCRIPTION
Using the find_device method instead of looking devices up in the map of
devices directly means child devices can be found, eg 'stage.x' could be
a valid device but isn't in the devices map in its own right.

There is still a bit of weirdness as querying `/devices/stage.x` will return a
`DeviceModel` with a name of `stage-x` but querying for `stage-x` will
fail with a 404.

Relates to #903 and #1137.