### PR TITLE
chore: update openapi schema to examples from example

### DIFF
--- a/docs/reference/openapi.yaml
+++ b/docs/reference/openapi.yaml
@@ -377,7 +377,7 @@ info:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
   title: BlueAPI Control
-  version: 1.1.1
+  version: 1.1.2
 openapi: 3.1.0
 paths:
   /config/oidc:
@@ -596,14 +596,14 @@ paths:
       requestBody:
         content:
           application/json:
-            example:
-              instrument_session: cm12345-1
-              name: count
-              params:
-                detectors:
-                - x
             schema:
               $ref: '#/components/schemas/TaskRequest'
+              examples:
+              - instrument_session: cm12345-1
+                name: count
+                params:
+                  detectors:
+                  - x
         required: true
       responses:
         '201':

--- a/src/blueapi/service/main.py
+++ b/src/blueapi/service/main.py
@@ -58,7 +58,7 @@ from .model import (
 from .runner import WorkerDispatcher
 
 #: API version to publish in OpenAPI schema
-REST_API_VERSION = "1.1.1"
+REST_API_VERSION = "1.1.2"
 
 LICENSE_INFO: dict[str, str] = {
     "name": "Apache 2.0",
@@ -298,7 +298,7 @@ example_task_request = TaskRequest(
 def submit_task(
     request: Request,
     response: Response,
-    task_request: Annotated[TaskRequest, Body(..., example=example_task_request)],
+    task_request: Annotated[TaskRequest, Body(..., examples=[example_task_request])],
     runner: Annotated[WorkerDispatcher, Depends(_runner)],
 ) -> TaskResponse:
     """Submit a task to the worker."""


### PR DESCRIPTION
```
 "Deprecated in OpenAPI 3.1.0 that now uses JSON Schema 2020-12, "
 "although still supported. Use examples instead."
```
Changed to examples so that lockfiles can be updated without deprecation warnings.
