### PR TITLE
feat: Log connected devices when using deviceManager

### DIFF
--- a/src/blueapi/core/context.py
+++ b/src/blueapi/core/context.py
@@ -296,6 +296,9 @@ class BlueskyContext:
             or build_result.connection_errors
         ):
             LOGGER.warning("Device manager did not build any devices")
+
+        utils.report_successful_devices(build_result.devices, mock)
+
         return build_result.devices, {
             **build_result.build_errors,
             **build_result.connection_errors,

--- a/src/blueapi/utils/__init__.py
+++ b/src/blueapi/utils/__init__.py
@@ -1,5 +1,5 @@
 from .base_model import BlueapiBaseModel, BlueapiModelConfig, BlueapiPlanModelConfig
-from .connect_devices import connect_devices
+from .connect_devices import connect_devices, report_successful_devices
 from .file_permissions import get_owner_gid, is_sgid_set
 from .invalid_config_error import InvalidConfigError
 from .modules import is_function_sourced_from_module, load_module_all
@@ -17,6 +17,7 @@ __all__ = [
     "InvalidConfigError",
     "NumtrackerClient",
     "connect_devices",
+    "report_successful_devices",
     "is_sgid_set",
     "get_owner_gid",
     "is_function_sourced_from_module",

--- a/src/blueapi/utils/connect_devices.py
+++ b/src/blueapi/utils/connect_devices.py
@@ -15,7 +15,7 @@ from ophyd_async.plan_stubs import ensure_connected
 LOGGER = logging.getLogger(__name__)
 
 
-def _report_successful_devices(
+def report_successful_devices(
     devices: Mapping[str, AnyDevice],
     sim_backend: bool,
 ) -> None:
@@ -86,7 +86,7 @@ def connect_devices(
         real_devices, exceptions = _establish_device_connections(
             run_engine, real_devices, False
         )
-        _report_successful_devices(real_devices, False)
+        report_successful_devices(real_devices, False)
         exception_map |= exceptions
     if len(sim_devices) > 0:
         sim_devices, exceptions = _establish_device_connections(
@@ -94,6 +94,6 @@ def connect_devices(
             sim_devices,  # type: ignore
             True,
         )
-        _report_successful_devices(sim_devices, True)
+        report_successful_devices(sim_devices, True)
         exception_map |= exceptions
     return exception_map


### PR DESCRIPTION
The report_successful_devices function should be moved when the dodal
module support is removed but it can stay where it is for now.