### PR TITLE
refactor: Re-export BlueapiClient from client root

### DIFF
--- a/src/blueapi/cli/cli.py
+++ b/src/blueapi/cli/cli.py
@@ -21,7 +21,7 @@ from requests.exceptions import ConnectionError
 
 from blueapi import __version__, config
 from blueapi.cli.format import OutputFormat
-from blueapi.client.client import BlueapiClient
+from blueapi.client import BlueapiClient
 from blueapi.client.event_bus import AnyEvent, BlueskyStreamingError, EventBusClient
 from blueapi.client.rest import (
     BlueskyRemoteControlError,

--- a/src/blueapi/client/__init__.py
+++ b/src/blueapi/client/__init__.py
@@ -1,0 +1,7 @@
+from .client import BlueapiClient
+from .rest import BlueapiRestClient
+
+__all__ = [
+    "BlueapiClient",
+    "BlueapiRestClient",
+]

--- a/tests/system_tests/test_blueapi_system.py
+++ b/tests/system_tests/test_blueapi_system.py
@@ -12,12 +12,12 @@ from pydantic import TypeAdapter
 from requests.exceptions import ConnectionError
 from scanspec.specs import Line
 
-from blueapi.client.client import (
-    BlueapiClient,
-    BlueskyRemoteControlError,
-)
+from blueapi.client import BlueapiClient
 from blueapi.client.event_bus import AnyEvent, BlueskyStreamingError
-from blueapi.client.rest import BlueskyRequestError
+from blueapi.client.rest import (
+    BlueskyRemoteControlError,
+    BlueskyRequestError,
+)
 from blueapi.config import (
     ApplicationConfig,
     ConfigLoader,

--- a/tests/unit_tests/client/test_client.py
+++ b/tests/unit_tests/client/test_client.py
@@ -9,7 +9,7 @@ from observability_utils.tracing import (
     asserting_span_exporter,
 )
 
-from blueapi.client.client import BlueapiClient
+from blueapi.client import BlueapiClient
 from blueapi.client.event_bus import AnyEvent, BlueskyStreamingError, EventBusClient
 from blueapi.client.rest import BlueapiRestClient, BlueskyRemoteControlError
 from blueapi.config import MissingStompConfigurationError


### PR DESCRIPTION
Allow the BlueapiClient to be imported from `blueapi.client` instead of
the repetitive `blueapi.client.client`.

The BlueapiRestClient is included as it may also be treated like an entry point
for scripts using blueapi as a library. For now, all other types (such as
exceptions) still need to be imported from their full module path.
