### PR TITLE
chore: Move cli tests into correct directory

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,7 +44,7 @@ def run_engine(request):
     return run_engine
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="session", autouse=True)
 def exporter() -> JsonObjectSpanExporter:
     setup_tracing("test", False)
     exporter = JsonObjectSpanExporter()

--- a/tests/unit_tests/cli/test_cli.py
+++ b/tests/unit_tests/cli/test_cli.py
@@ -1,4 +1,3 @@
-import importlib
 import json
 import os
 import uuid
@@ -18,7 +17,6 @@ from bluesky.protocols import Movable
 from bluesky_stomp.messaging import StompClient
 from bluesky_stomp.models import MessageTopic
 from click.testing import CliRunner
-from opentelemetry import trace
 from ophyd_async.core import AsyncStatus
 from pydantic import BaseModel
 from requests.exceptions import ConnectionError
@@ -61,18 +59,6 @@ from blueapi.worker.event import (
     WorkerEvent,
     WorkerState,
 )
-
-
-@pytest.fixture(autouse=True)
-def reload_opentelemetry_trace_after_tests():
-    """Reload opentelemetry.trace after running each test.
-
-    OpenTelemetry only allows one global TracerProvider, however most cli entry-points
-    overwrite this to set up tracing. As OpenTelemetry does not have any functions to
-    aid testing, the library init has to be reloaded after each test to avoid errors.
-    """
-    yield
-    importlib.reload(trace)
 
 
 @pytest.fixture


### PR DESCRIPTION
The cli tests were in the root unit test dir, when the cli now has its own module. This makes it match the src layout.