### PR TITLE
Improve HTTP error handling for 401/403 and replace KeyError for 404

### DIFF
--- a/src/blueapi/client/rest.py
+++ b/src/blueapi/client/rest.py
@@ -1,4 +1,3 @@
-import code
 from collections.abc import Callable, Mapping
 from typing import Any, Literal, TypeVar
 


### PR DESCRIPTION
This PR improves HTTP error handling in the client.

Changes:
- Added explicit handling for 401 (Unauthorized) and 403 (Forbidden) status codes.
- Replaced the use of KeyError for 404 responses with a more appropriate API error.
- Improved error messages for better clarity and debugging.

This aligns error handling more closely with standard HTTP semantics and avoids using KeyError for non-dictionary-related issues.

Fixes #1409