### PR TITLE
chore: Improve default error handling and fix stacktrace #1379 #1409 

### DIFF
--- a/src/blueapi/cli/cli.py
+++ b/src/blueapi/cli/cli.py
@@ -217,13 +217,12 @@ def check_connection(func: Callable[P, T]) -> Callable[P, T]:
             raise ClickException(
                 "Failed to establish connection to blueapi server."
             ) from ce
+        except UnauthorisedAccessError as e:
+            raise ClickException(
+                "Access denied. Please check your login status and try again."
+            ) from e
         except BlueskyRemoteControlError as e:
-            if str(e) == "<Response [401]>":
-                raise ClickException(
-                    "Access denied. Please check your login status and try again."
-                ) from e
-            else:
-                raise e
+            raise e
 
     return wrapper
 
@@ -357,7 +356,12 @@ def run_plan(
     except InvalidParametersError as ip:
         raise ClickException(ip.message()) from ip
     except (BlueskyRemoteControlError, BlueskyStreamingError) as e:
-        raise ClickException(f"server error with this message: {e}") from e
+        message = (
+            e.args[1]
+            if isinstance(e, BlueskyRemoteControlError) and len(e.args) > 1
+            else str(e)
+        )
+        raise ClickException(f"server error with this message: {message}") from e
     except ValueError as ve:
         raise ClickException(f"task could not run: {ve}") from ve
 

--- a/src/blueapi/client/client.py
+++ b/src/blueapi/client/client.py
@@ -498,7 +498,7 @@ class BlueapiClient:
                     if event.task_status is None:
                         complete.set_exception(
                             BlueskyRemoteControlError(
-                                "Server completed without task status"
+                                message="Server completed without task status"
                             )
                         )
                     else:
@@ -530,7 +530,7 @@ class BlueapiClient:
             return response
         else:
             raise BlueskyRemoteControlError(
-                f"Tried to create and start task {response.task_id} "
+                message=f"Tried to create and start task {response.task_id} "
                 f"but {worker_response.task_id} was started instead"
             )
 
@@ -659,7 +659,7 @@ class BlueapiClient:
             status = self._rest.delete_environment()
         except Exception as e:
             raise BlueskyRemoteControlError(
-                "Failed to tear down the environment"
+                message="Failed to tear down the environment"
             ) from e
         return self._wait_for_reload(
             status,
@@ -684,7 +684,7 @@ class BlueapiClient:
             status = self._rest.get_environment()
             if status.error_message is not None:
                 raise BlueskyRemoteControlError(
-                    f"Error reloading environment: {status.error_message}"
+                    message=f"Error reloading environment: {status.error_message}"
                 )
             elif (
                 status.initialized and status.environment_id != previous_environment_id

--- a/src/blueapi/client/rest.py
+++ b/src/blueapi/client/rest.py
@@ -33,17 +33,25 @@ T = TypeVar("T")
 TRACER = get_tracer("rest")
 
 
-class UnauthorisedAccessError(Exception):
-    pass
-
-
-class BlueskyRemoteControlError(Exception):
-    pass
-
-
 class BlueskyRequestError(Exception):
-    def __init__(self, code: int, message: str) -> None:
-        super().__init__(message, code)
+    def __init__(self, code: int | None = None, message: str = "") -> None:
+        super().__init__(code, message)
+
+
+class UnauthorisedAccessError(BlueskyRequestError):
+    pass
+
+
+class BlueskyRemoteControlError(BlueskyRequestError):
+    pass
+
+
+class NotFoundError(BlueskyRequestError):
+    pass
+
+
+class UnknownPlanError(BlueskyRequestError):
+    pass
 
 
 class NoContentError(Exception):
@@ -96,16 +104,14 @@ class InvalidParametersError(Exception):
         )
 
 
-class UnknownPlanError(Exception):
-    pass
-
-
 def _exception(response: requests.Response) -> Exception | None:
     code = response.status_code
     if code < 400:
         return None
+    elif code in (401, 403):
+        return UnauthorisedAccessError(code, str(response))
     elif code == 404:
-        return KeyError(str(response.json()))
+        return NotFoundError(code, str(response))
     else:
         return BlueskyRemoteControlError(code, str(response))
 
@@ -115,9 +121,9 @@ def _create_task_exceptions(response: requests.Response) -> Exception | None:
     if code < 400:
         return None
     elif code == 401 or code == 403:
-        return UnauthorisedAccessError()
+        return UnauthorisedAccessError(code, str(response))
     elif code == 404:
-        return UnknownPlanError()
+        return UnknownPlanError(code, str(response))
     elif code == 422:
         try:
             content = response.json()
@@ -129,9 +135,9 @@ def _create_task_exceptions(response: requests.Response) -> Exception | None:
         except Exception:
             # If the error can't be parsed into something sensible, return the
             # raw text in a generic exception so at least it gets reported
-            return BlueskyRequestError(code, response.text)
+            return BlueskyRequestError(code, str(response))
     else:
-        return BlueskyRequestError(code, response.text)
+        return BlueskyRequestError(code, str(response))
 
 
 class BlueapiRestClient:

--- a/tests/unit_tests/cli/test_cli.py
+++ b/tests/unit_tests/cli/test_cli.py
@@ -118,9 +118,8 @@ def test_connection_error_caught_by_wrapper_func(
 def test_authentication_error_caught_by_wrapper_func(
     mock_requests: Mock, runner: CliRunner
 ):
-    mock_requests.side_effect = BlueskyRemoteControlError("<Response [401]>")
+    mock_requests.side_effect = UnauthorisedAccessError(message="<Response [401]>")
     result = runner.invoke(main, ["controller", "plans"])
-
     assert (
         result.output
         == "Error: Access denied. Please check your login status and try again.\n"
@@ -129,12 +128,11 @@ def test_authentication_error_caught_by_wrapper_func(
 
 @patch("blueapi.client.rest.requests.Session.request")
 def test_remote_error_raised_by_wrapper_func(mock_requests: Mock, runner: CliRunner):
-    mock_requests.side_effect = BlueskyRemoteControlError("Response [450]")
-
+    mock_requests.side_effect = BlueskyRemoteControlError(message="Response [450]")
     result = runner.invoke(main, ["controller", "plans"])
     assert (
         isinstance(result.exception, BlueskyRemoteControlError)
-        and result.exception.args == ("Response [450]",)
+        and result.exception.args[1] == "Response [450]"
         and result.exit_code == 1
     )
 
@@ -680,7 +678,7 @@ def test_env_reload_server_side_error(runner: CliRunner):
     assert isinstance(result.exception, BlueskyRemoteControlError), (
         "Expected a BlueskyRemoteError from cli runner"
     )
-    assert result.exception.args[0] == "Failed to tear down the environment"
+    assert result.exception.args[1] == "Failed to tear down the environment"
 
     # Check if the endpoints were hit as expected
     assert len(responses.calls) == 1  # +1 for the DELETE call
@@ -716,7 +714,7 @@ def test_env_reload_server_side_error(runner: CliRunner):
             "Error: Incorrect parameters supplied\n    Missing value for 'foo'\n",
         ),
         (
-            BlueskyRemoteControlError("Server error"),
+            BlueskyRemoteControlError(message="Server error"),
             "Error: server error with this message: Server error\n",
         ),
         (

--- a/tests/unit_tests/client/test_client.py
+++ b/tests/unit_tests/client/test_client.py
@@ -214,7 +214,7 @@ def test_create_and_start_task_fails_if_task_creation_fails(
     client: BlueapiClient,
     mock_rest: Mock,
 ):
-    mock_rest.create_task.side_effect = BlueskyRemoteControlError("No can do")
+    mock_rest.create_task.side_effect = BlueskyRemoteControlError(message="No can do")
     with pytest.raises(BlueskyRemoteControlError):
         client.create_and_start_task(
             TaskRequest(name="baz", instrument_session="cm12345-1")
@@ -238,7 +238,9 @@ def test_create_and_start_task_fails_if_task_start_fails(
     mock_rest: Mock,
 ):
     mock_rest.create_task.return_value = TaskResponse(task_id="baz")
-    mock_rest.update_worker_task.side_effect = BlueskyRemoteControlError("No can do")
+    mock_rest.update_worker_task.side_effect = BlueskyRemoteControlError(
+        message="No can do"
+    )
     with pytest.raises(BlueskyRemoteControlError):
         client.create_and_start_task(
             TaskRequest(name="baz", instrument_session="cm12345-1")

--- a/tests/unit_tests/client/test_rest.py
+++ b/tests/unit_tests/client/test_rest.py
@@ -11,6 +11,7 @@ from blueapi.client.rest import (
     BlueskyRemoteControlError,
     BlueskyRequestError,
     InvalidParametersError,
+    NotFoundError,
     ParameterError,
     UnauthorisedAccessError,
     UnknownPlanError,
@@ -39,8 +40,9 @@ def rest_with_auth(oidc_config: OIDCConfig, tmp_path) -> BlueapiRestClient:
 @pytest.mark.parametrize(
     "code,expected_exception",
     [
-        (404, KeyError),
-        (401, BlueskyRemoteControlError),
+        (404, NotFoundError),
+        (401, UnauthorisedAccessError),
+        (403, UnauthorisedAccessError),
         (450, BlueskyRemoteControlError),
         (500, BlueskyRemoteControlError),
     ],
@@ -63,9 +65,9 @@ def test_rest_error_code(
     "code,content,expected_exception",
     [
         (200, None, None),
-        (401, None, UnauthorisedAccessError()),
-        (403, None, UnauthorisedAccessError()),
-        (404, None, UnknownPlanError()),
+        (401, None, UnauthorisedAccessError(401, "")),
+        (403, None, UnauthorisedAccessError(403, "")),
+        (404, None, UnknownPlanError(404, "")),
         (
             422,
             """{
@@ -102,8 +104,11 @@ def test_create_task_exceptions(
     response.json.side_effect = lambda: json.loads(content) if content else None
     err = _create_task_exceptions(response)
     assert isinstance(err, type(expected_exception))
-    if expected_exception is not None:
-        assert err.args == expected_exception.args
+    if isinstance(expected_exception, InvalidParametersError):
+        assert isinstance(err, InvalidParametersError)
+        assert err.errors == expected_exception.errors
+    elif expected_exception is not None:
+        assert err.args[0] == code
 
 
 def test_auth_request_functionality(


### PR DESCRIPTION
Fixes #1379
Fixes #1409

Both issues related to error handling in the REST client.

#1379 - String matching in `check_connection` broke in #935 when the 
error format changed to include the status code.
Fixed by catching 'UnauthorisedAccessError' instead of string matching, this was fixed in 1409

#1409 - Expanded the exception handler to raise different types per 
status code rather than bundling everything into `BlueskyRemoteControlError`.