### PR TITLE
feat: Add --verbose/--quiet flags to cli

### DIFF
--- a/src/blueapi/cli/cli.py
+++ b/src/blueapi/cli/cli.py
@@ -83,8 +83,24 @@ def is_str_dict(val: Any) -> TypeGuard[TaskParameters]:
 @click.option(
     "-c", "--config", type=Path, help="Path to configuration YAML file", multiple=True
 )
+@click.option(
+    "-v",
+    "--verbose",
+    "log_level",
+    flag_value="DEBUG",
+    help="Include DEBUG level logging output",
+)
+@click.option(
+    "-q",
+    "--quiet",
+    "log_level",
+    flag_value="ERROR",
+    help="Reduce logging noise to only show errors",
+)
 @click.pass_context
-def main(ctx: click.Context, config: tuple[Path, ...]) -> None:
+def main(
+    ctx: click.Context, config: tuple[Path, ...], log_level: str | None = None
+) -> None:
     # if no command is supplied, run with the options passed
 
     # Set umask to DLS standard
@@ -95,6 +111,9 @@ def main(ctx: click.Context, config: tuple[Path, ...]) -> None:
         config_loader.use_values_from_yaml(*config)
     except FileNotFoundError as fnfe:
         raise ClickException(f"Config file not found: {fnfe.filename}") from fnfe
+
+    if log_level:
+        config_loader.use_values({"logging": {"level": log_level}})
 
     loaded_config: ApplicationConfig = config_loader.load()
 

--- a/tests/unit_tests/cli/test_cli.py
+++ b/tests/unit_tests/cli/test_cli.py
@@ -1384,3 +1384,14 @@ def test_config_schema(
 def test_task_parameter_type(value, result):
     t = ParametersType()
     assert t.convert(value, None, None) == result
+
+
+@pytest.mark.parametrize(
+    "flag,level",
+    [("--verbose", "DEBUG"), ("--quiet", "ERROR"), ("-v", "DEBUG"), ("-q", "ERROR")],
+)
+def test_log_level_override(flag: str, level: str, runner: CliRunner):
+    with patch("blueapi.log.logging") as mock_log:
+        runner.invoke(main, [flag])
+        mock_log.getLogger().setLevel.assert_called_once_with(level)
+        mock_log.StreamHandler().setLevel.assert_called_once_with(level)


### PR DESCRIPTION
Allows the logging to be configured from the CLI instead of requiring a
configuration file.

Verbose option increases logging to DEBUG level while quiet reduces it
to ERROR only. If both options are passed, the second option overrides
the first.
