### PR TITLE
feat: Checkout tags as well as branches when cloning into scratch

### DIFF
--- a/helm/blueapi/config_schema.json
+++ b/helm/blueapi/config_schema.json
@@ -431,7 +431,7 @@
                     "type": "string"
                 },
                 "branch": {
-                    "description": "Branch of repo to check out - defaults to remote's default when cloning and the existing branch when the repo already exists",
+                    "description": "Branch (or tag) to check out when cloning - defaults to remote's HEAD. If a tag is used, the repo will be left in a 'detached head' state.",
                     "title": "Branch",
                     "type": "string"
                 }

--- a/helm/blueapi/config_schema.json
+++ b/helm/blueapi/config_schema.json
@@ -430,9 +430,9 @@
                     "title": "Remote Url",
                     "type": "string"
                 },
-                "branch": {
-                    "description": "Branch (or tag) to check out when cloning - defaults to remote's HEAD. If a tag is used, the repo will be left in a 'detached head' state.",
-                    "title": "Branch",
+                "target_revision": {
+                    "description": "Revision (branch or tag) to check out when cloning - defaults to remote's HEAD. If a tag is used, the repo will be left in a 'detached head' state.",
+                    "title": "Target Revision",
                     "type": "string"
                 }
             },

--- a/helm/blueapi/values.schema.json
+++ b/helm/blueapi/values.schema.json
@@ -854,7 +854,7 @@
             "properties": {
                 "branch": {
                     "title": "Branch",
-                    "description": "Branch of repo to check out - defaults to remote's default when cloning and the existing branch when the repo already exists",
+                    "description": "Branch (or tag) to check out when cloning - defaults to remote's HEAD. If a tag is used, the repo will be left in a 'detached head' state.",
                     "type": "string"
                 },
                 "name": {

--- a/helm/blueapi/values.schema.json
+++ b/helm/blueapi/values.schema.json
@@ -852,11 +852,6 @@
             "title": "ScratchRepository",
             "type": "object",
             "properties": {
-                "branch": {
-                    "title": "Branch",
-                    "description": "Branch (or tag) to check out when cloning - defaults to remote's HEAD. If a tag is used, the repo will be left in a 'detached head' state.",
-                    "type": "string"
-                },
                 "name": {
                     "title": "Name",
                     "description": "Unique name for this repository in the scratch directory",
@@ -867,6 +862,11 @@
                     "title": "Remote Url",
                     "description": "URL to clone from",
                     "default": "https://github.com/example/example.git",
+                    "type": "string"
+                },
+                "target_revision": {
+                    "title": "Target Revision",
+                    "description": "Revision (branch or tag) to check out when cloning - defaults to remote's HEAD. If a tag is used, the repo will be left in a 'detached head' state.",
                     "type": "string"
                 }
             },

--- a/src/blueapi/cli/scratch.py
+++ b/src/blueapi/cli/scratch.py
@@ -48,12 +48,15 @@ def setup_scratch(
             )
     for repo in config.repositories:
         local_directory = config.root / repo.name
-        ensure_repo(repo.remote_url, local_directory, repo.branch)
+        ensure_repo(repo.remote_url, local_directory, repo.branch, repo.tag)
         scratch_install(local_directory, timeout=install_timeout)
 
 
 def ensure_repo(
-    remote_url: str, local_directory: Path, branch: str | None = None
+    remote_url: str,
+    local_directory: Path,
+    branch: str | None = None,
+    tag: str | None = None,
 ) -> None:
     """
     Ensure that a repository is checked out for use in the scratch area.
@@ -64,6 +67,9 @@ def ensure_repo(
         local_directory: Output path for cloning
     """
 
+    if tag and branch:
+        raise ValueError(f"Can't use both branch ({branch!r}) and tag ({tag!r})")
+
     # Set umask to DLS standard
     os.umask(stat.S_IWOTH)
 
@@ -71,26 +77,32 @@ def ensure_repo(
         LOGGER.info(f"Cloning {remote_url}")
         repo = Repo.clone_from(remote_url, local_directory)
         LOGGER.info(f"Cloned {remote_url} -> {local_directory}")
+        if branch:
+            if not (local := getattr(repo.heads, branch, None)):
+                origin = repo.remotes[0]
+                origin.fetch()
+                LOGGER.info(
+                    "Creating branch '%s' to track remote '%s'",
+                    branch,
+                    origin.refs[branch],
+                )
+                local = repo.create_head(branch, origin.refs[branch])
+                local.set_tracking_branch(origin.refs[branch])
+
+            LOGGER.info("Checking out branch %r", branch)
+            local.checkout()
+        elif tag:
+            if tag_obj := getattr(repo.tags, tag, None):
+                LOGGER.info("Checking out tag %r", tag)
+                tag_obj.checkout()
+            else:
+                raise ValueError("Could not find tag: " + repr(tag))
     elif local_directory.is_dir():
-        repo = Repo(local_directory)
         LOGGER.info(f"Found {local_directory}")
     else:
         raise KeyError(
             f"Unable to open {local_directory} as a git repository because it is a file"
         )
-
-    if branch:
-        if not (local := getattr(repo.heads, branch, None)):
-            origin = repo.remotes[0]
-            origin.fetch()
-            LOGGER.info(
-                "Creating branch '%s' to track remote '%s'", branch, origin.refs[branch]
-            )
-            local = repo.create_head(branch, origin.refs[branch])
-            local.set_tracking_branch(origin.refs[branch])
-
-        LOGGER.info("Checking out branch '%s'", branch)
-        local.checkout()
 
 
 def scratch_install(path: Path, timeout: float = _DEFAULT_INSTALL_TIMEOUT) -> None:

--- a/src/blueapi/cli/scratch.py
+++ b/src/blueapi/cli/scratch.py
@@ -48,15 +48,12 @@ def setup_scratch(
             )
     for repo in config.repositories:
         local_directory = config.root / repo.name
-        ensure_repo(repo.remote_url, local_directory, repo.branch, repo.tag)
+        ensure_repo(repo.remote_url, local_directory, repo.branch)
         scratch_install(local_directory, timeout=install_timeout)
 
 
 def ensure_repo(
-    remote_url: str,
-    local_directory: Path,
-    branch: str | None = None,
-    tag: str | None = None,
+    remote_url: str, local_directory: Path, branch: str | None = None
 ) -> None:
     """
     Ensure that a repository is checked out for use in the scratch area.
@@ -67,41 +64,20 @@ def ensure_repo(
         local_directory: Output path for cloning
     """
 
-    if tag and branch:
-        raise ValueError(f"Can't use both branch ({branch!r}) and tag ({tag!r})")
-
     # Set umask to DLS standard
     os.umask(stat.S_IWOTH)
 
     if not local_directory.exists():
         LOGGER.info(f"Cloning {remote_url}")
-        repo = Repo.clone_from(remote_url, local_directory)
+        Repo.clone_from(remote_url, local_directory, branch=branch)
         LOGGER.info(f"Cloned {remote_url} -> {local_directory}")
-        if branch:
-            if not (local := getattr(repo.heads, branch, None)):
-                origin = repo.remotes[0]
-                origin.fetch()
-                LOGGER.info(
-                    "Creating branch '%s' to track remote '%s'",
-                    branch,
-                    origin.refs[branch],
-                )
-                local = repo.create_head(branch, origin.refs[branch])
-                local.set_tracking_branch(origin.refs[branch])
-
-            LOGGER.info("Checking out branch %r", branch)
-            local.checkout()
-        elif tag:
-            if tag_obj := getattr(repo.tags, tag, None):
-                LOGGER.info("Checking out tag %r", tag)
-                tag_obj.checkout()
-            else:
-                raise ValueError("Could not find tag: " + repr(tag))
     elif local_directory.is_dir():
+        Repo(local_directory)
         LOGGER.info(f"Found {local_directory}")
     else:
         raise KeyError(
-            f"Unable to open {local_directory} as a git repository because it is a file"
+            f"Unable to open {local_directory} as a git repository because it is not a "
+            "directory"
         )
 
 

--- a/src/blueapi/cli/scratch.py
+++ b/src/blueapi/cli/scratch.py
@@ -48,12 +48,12 @@ def setup_scratch(
             )
     for repo in config.repositories:
         local_directory = config.root / repo.name
-        ensure_repo(repo.remote_url, local_directory, repo.branch)
+        ensure_repo(repo.remote_url, local_directory, repo.target_revision)
         scratch_install(local_directory, timeout=install_timeout)
 
 
 def ensure_repo(
-    remote_url: str, local_directory: Path, branch: str | None = None
+    remote_url: str, local_directory: Path, target_revision: str | None = None
 ) -> None:
     """
     Ensure that a repository is checked out for use in the scratch area.
@@ -69,11 +69,23 @@ def ensure_repo(
 
     if not local_directory.exists():
         LOGGER.info(f"Cloning {remote_url}")
-        Repo.clone_from(remote_url, local_directory, branch=branch)
+        Repo.clone_from(remote_url, local_directory, branch=target_revision)
         LOGGER.info(f"Cloned {remote_url} -> {local_directory}")
     elif local_directory.is_dir():
-        Repo(local_directory)
-        LOGGER.info(f"Found {local_directory}")
+        repo = Repo(local_directory)
+        head = repo.head.commit
+        LOGGER.info("Found %s @ %s", local_directory, head.name_rev)
+        if target_revision:
+            if target_revision in repo.refs:
+                if repo.refs[target_revision].commit != head:
+                    LOGGER.warning(
+                        "Repository %s not at target revision: %r instead of %r",
+                        local_directory.name,
+                        head.name_rev,
+                        target_revision,
+                    )
+            else:
+                LOGGER.warning("Target revision %r not found", target_revision)
     else:
         raise KeyError(
             f"Unable to open {local_directory} as a git repository because it is not a "

--- a/src/blueapi/config.py
+++ b/src/blueapi/config.py
@@ -6,7 +6,7 @@ from enum import StrEnum
 from functools import cached_property
 from pathlib import Path
 from string import Template
-from typing import Annotated, Any, ClassVar, Generic, Literal, TypeVar, cast
+from typing import Annotated, Any, ClassVar, Generic, Literal, Self, TypeVar, cast
 
 import requests
 import yaml
@@ -21,6 +21,7 @@ from pydantic import (
     UrlConstraints,
     ValidationError,
     field_validator,
+    model_validator,
 )
 from pydantic.json_schema import SkipJsonSchema
 
@@ -192,10 +193,14 @@ class ScratchRepository(BlueapiBaseModel):
         default="https://github.com/example/example.git",
     )
     branch: str | SkipJsonSchema[None] = Field(
-        description=(
-            "Branch of repo to check out - defaults to remote's default when "
-            "cloning and the existing branch when the repo already exists"
-        ),
+        description="Branch of repo to check out - defaults to remote's default",
+        exclude_if=lambda f: f is None,
+        # using default_factory instead of default means the schema doesn't
+        # include an invalid value
+        default_factory=lambda: None,
+    )
+    tag: str | SkipJsonSchema[None] = Field(
+        description="Tag of repo to check out.",
         exclude_if=lambda f: f is None,
         # using default_factory instead of default means the schema doesn't
         # include an invalid value
@@ -208,6 +213,14 @@ class ScratchRepository(BlueapiBaseModel):
         if value == FORBIDDEN_OWN_REMOTE_URL:
             raise ValueError(f"remote_url '{value}' is not allowed.")
         return value
+
+    @model_validator(mode="after")
+    def check_clone_options(self) -> Self:
+        if self.branch is not None and self.tag is not None:
+            raise ValueError(
+                f"Cannot set both branch ({self.branch}) and tag ({self.tag})"
+            )
+        return self
 
 
 class ScratchConfig(BlueapiBaseModel):

--- a/src/blueapi/config.py
+++ b/src/blueapi/config.py
@@ -6,7 +6,7 @@ from enum import StrEnum
 from functools import cached_property
 from pathlib import Path
 from string import Template
-from typing import Annotated, Any, ClassVar, Generic, Literal, Self, TypeVar, cast
+from typing import Annotated, Any, ClassVar, Generic, Literal, TypeVar, cast
 
 import requests
 import yaml
@@ -21,7 +21,6 @@ from pydantic import (
     UrlConstraints,
     ValidationError,
     field_validator,
-    model_validator,
 )
 from pydantic.json_schema import SkipJsonSchema
 
@@ -193,14 +192,10 @@ class ScratchRepository(BlueapiBaseModel):
         default="https://github.com/example/example.git",
     )
     branch: str | SkipJsonSchema[None] = Field(
-        description="Branch of repo to check out - defaults to remote's default",
-        exclude_if=lambda f: f is None,
-        # using default_factory instead of default means the schema doesn't
-        # include an invalid value
-        default_factory=lambda: None,
-    )
-    tag: str | SkipJsonSchema[None] = Field(
-        description="Tag of repo to check out.",
+        description=(
+            "Branch (or tag) to check out when cloning - defaults to remote's HEAD. "
+            "If a tag is used, the repo will be left in a 'detached head' state."
+        ),
         exclude_if=lambda f: f is None,
         # using default_factory instead of default means the schema doesn't
         # include an invalid value
@@ -213,14 +208,6 @@ class ScratchRepository(BlueapiBaseModel):
         if value == FORBIDDEN_OWN_REMOTE_URL:
             raise ValueError(f"remote_url '{value}' is not allowed.")
         return value
-
-    @model_validator(mode="after")
-    def check_clone_options(self) -> Self:
-        if self.branch is not None and self.tag is not None:
-            raise ValueError(
-                f"Cannot set both branch ({self.branch}) and tag ({self.tag})"
-            )
-        return self
 
 
 class ScratchConfig(BlueapiBaseModel):

--- a/src/blueapi/config.py
+++ b/src/blueapi/config.py
@@ -12,6 +12,7 @@ import requests
 import yaml
 from bluesky_stomp.models import BasicAuthentication
 from pydantic import (
+    AliasChoices,
     AnyUrl,
     BaseModel,
     Field,
@@ -191,11 +192,13 @@ class ScratchRepository(BlueapiBaseModel):
         description="URL to clone from",
         default="https://github.com/example/example.git",
     )
-    branch: str | SkipJsonSchema[None] = Field(
+    target_revision: str | SkipJsonSchema[None] = Field(
         description=(
-            "Branch (or tag) to check out when cloning - defaults to remote's HEAD. "
-            "If a tag is used, the repo will be left in a 'detached head' state."
+            "Revision (branch or tag) to check out when cloning - defaults to "
+            "remote's HEAD. If a tag is used, the repo will be left in a "
+            "'detached head' state."
         ),
+        validation_alias=AliasChoices("branch", "tag", "target_revision"),
         exclude_if=lambda f: f is None,
         # using default_factory instead of default means the schema doesn't
         # include an invalid value
@@ -455,5 +458,5 @@ def generate_config_schema() -> dict[str, Any]:
             return json_schema
 
     return ApplicationConfig.model_json_schema(
-        schema_generator=_GenerateJsonSchema, ref_template="{model}"
+        by_alias=False, schema_generator=_GenerateJsonSchema, ref_template="{model}"
     )

--- a/tests/unit_tests/cli/test_cli.py
+++ b/tests/unit_tests/cli/test_cli.py
@@ -1055,7 +1055,22 @@ def test_init_scratch_calls_setup_scratch(mock_setup_scratch: Mock, runner: CliR
             ScratchRepository(
                 name="dodal",
                 remote_url="https://github.com/DiamondLightSource/dodal.git",
-            )
+            ),
+            ScratchRepository(
+                name="with_target",
+                remote_url="https://github.com/DiamondLightSource/dodal.git",
+                target_revision="demo",
+            ),
+            ScratchRepository(
+                name="with_branch",
+                remote_url="https://github.com/DiamondLightSource/dodal.git",
+                target_revision="demo_branch",
+            ),
+            ScratchRepository(
+                name="with_tag",
+                remote_url="https://github.com/DiamondLightSource/dodal.git",
+                target_revision="demo_tag",
+            ),
         ],
     )
 

--- a/tests/unit_tests/cli/test_scratch.py
+++ b/tests/unit_tests/cli/test_scratch.py
@@ -123,7 +123,7 @@ def test_repo_cloned_if_not_found_locally(
     ensure_repo("http://example.com/foo.git", nonexistant_path)
     mock_repo.assert_not_called()
     mock_repo.clone_from.assert_called_once_with(
-        "http://example.com/foo.git", nonexistant_path
+        "http://example.com/foo.git", nonexistant_path, branch=None
     )
 
 
@@ -140,7 +140,7 @@ def test_repo_cloned_with_correct_umask(
         with file_path.open("w") as stream:
             stream.write("foo")
 
-    mock_repo.clone_from.side_effect = lambda url, path: write_repo_files()
+    mock_repo.clone_from.side_effect = lambda url, path, branch=None: write_repo_files()
 
     ensure_repo("http://example.com/foo.git", repo_root)
     assert file_path.exists()
@@ -162,26 +162,23 @@ def test_cloned_repo_changes_to_new_branch(mock_repo, directory_path: Path):
 
     ensure_repo("http://example.com/foo.git", directory_path / "demo_branch", "demo")
 
-    mock_repo.clone_from.assert_called_once_with("http://example.com/foo.git", ANY)
-    repo.create_head.assert_called_once_with("demo", ANY)
-    repo.create_head().checkout.assert_called_once()
+    mock_repo.clone_from.assert_called_once_with(
+        "http://example.com/foo.git", ANY, branch="demo"
+    )
 
 
 @patch("blueapi.cli.scratch.Repo")
-def test_existing_repo_changes_to_existing_branch(mock_repo, directory_path: Path):
+def test_existing_repo_not_changed_to_existing_branch(mock_repo, directory_path: Path):
     (directory_path / "demo_branch").mkdir()
-    repo = Mock(spec=Repo)
-    mock_repo.return_value = repo
 
     ensure_repo("http://example.com/foo.git", directory_path / "demo_branch", "demo")
 
+    mock_repo.assert_called_once_with(directory_path / "demo_branch")
     mock_repo.clone_from.assert_not_called()
-    repo.create_head.assert_not_called()
-    repo.heads.demo.checkout.assert_called_once()
 
 
 @patch("blueapi.cli.scratch.Repo")
-def test_existing_repo_changes_to_new_branch(mock_repo, directory_path: Path):
+def test_existing_repo_not_changed_to_new_branch(mock_repo, directory_path: Path):
     (directory_path / "demo_branch").mkdir()
     repo = MagicMock(name="ExistingRepo", spec=Repo)
     repo.heads.demo = None
@@ -190,8 +187,7 @@ def test_existing_repo_changes_to_new_branch(mock_repo, directory_path: Path):
     ensure_repo("http://example.com/foo.git", directory_path / "demo_branch", "demo")
 
     mock_repo.clone_from.assert_not_called()
-    repo.create_head.assert_called_once_with("demo", repo.remotes[0].refs["demo"])
-    repo.create_head().checkout.assert_called_once()
+    repo.create_head.assert_not_called()
 
 
 def test_setup_scratch_fails_on_nonexistant_root(
@@ -292,10 +288,7 @@ def test_setup_scratch_iterates_repos(
     config = ScratchConfig(
         root=directory_path_with_sgid,
         repositories=[
-            ScratchRepository(
-                name="foo",
-                remote_url="http://example.com/foo.git",
-            ),
+            ScratchRepository(name="foo", remote_url="http://example.com/foo.git"),
             ScratchRepository(
                 name="bar",
                 remote_url="http://example.com/bar.git",

--- a/tests/unit_tests/cli/test_scratch.py
+++ b/tests/unit_tests/cli/test_scratch.py
@@ -190,6 +190,42 @@ def test_existing_repo_not_changed_to_new_branch(mock_repo, directory_path: Path
     repo.create_head.assert_not_called()
 
 
+@patch("blueapi.cli.scratch.Repo")
+@patch("blueapi.cli.scratch.LOGGER")
+def test_existing_repo_state_checked(
+    mock_logger: MagicMock, mock_repo: MagicMock, directory_path: Path
+):
+    repo = mock_repo.return_value
+    repo.head.commit.name_rev = "current"
+    repo.refs = {"demo": Mock()}
+
+    ensure_repo("http://example.com/foo.git", directory_path, "demo")
+
+    mock_logger.warning.assert_called_once_with(
+        "Repository %s not at target revision: %r instead of %r",
+        directory_path.name,
+        repo.head.commit.name_rev,
+        "demo",
+    )
+
+
+@patch("blueapi.cli.scratch.Repo")
+@patch("blueapi.cli.scratch.LOGGER")
+def test_existing_repo_unknown_revision(
+    mock_logger: MagicMock, mock_repo: MagicMock, directory_path: Path
+):
+    repo = mock_repo.return_value
+    repo.head.commit.name_rev = "current"
+    repo.refs = {}
+
+    ensure_repo("http://example.com/foo.git", directory_path, "demo")
+
+    mock_logger.warning.assert_called_once_with(
+        "Target revision %r not found",
+        "demo",
+    )
+
+
 def test_setup_scratch_fails_on_nonexistant_root(
     nonexistant_path: Path,
 ):

--- a/tests/unit_tests/cli/test_scratch.py
+++ b/tests/unit_tests/cli/test_scratch.py
@@ -292,7 +292,7 @@ def test_setup_scratch_iterates_repos(
             ScratchRepository(
                 name="bar",
                 remote_url="http://example.com/bar.git",
-                branch="demo",
+                target_revision="demo",
             ),
         ],
     )

--- a/tests/unit_tests/example_yaml/scratch.yaml
+++ b/tests/unit_tests/example_yaml/scratch.yaml
@@ -3,3 +3,12 @@ scratch:
   repositories:
     - name: dodal
       remote_url: https://github.com/DiamondLightSource/dodal.git
+    - name: with_target
+      remote_url: https://github.com/DiamondLightSource/dodal.git
+      target_revision: demo
+    - name: with_branch
+      remote_url: https://github.com/DiamondLightSource/dodal.git
+      branch: demo_branch
+    - name: with_tag
+      remote_url: https://github.com/DiamondLightSource/dodal.git
+      tag: demo_tag

--- a/tests/unit_tests/test_helm_chart.py
+++ b/tests/unit_tests/test_helm_chart.py
@@ -84,7 +84,7 @@ LOW_RESOURCES = {
                     ScratchRepository(
                         name="bar",
                         remote_url="https://example.git",
-                        branch="bar_branch",
+                        target_revision="bar_branch",
                     ),
                 ],
             ),


### PR DESCRIPTION
The branch field in the config file can now be set to the value of a
tag. While it could be confusing to use 'branch' for both, it mirrors
the behaviour of the `--branch` flag when cloning repositories with the
git CLI.

In a slight change in behaviour, the branch field is now only used when
first cloning a repository - if it already exists in the scratch area it
will be left in the same state. This is to avoid the ambiguity of how
tags should behave when the repo has been modified since being cloned.
