### PR TITLE
chore: Remove references to blueapi/startup

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -4,5 +4,3 @@ coverage:
       default:
         target: 85% # the required coverage value
         threshold: 1% # the leniency in hitting the target
-ignore:
-  - "src/blueapi/startup"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,10 +95,7 @@ reportMissingImports = false  # Ignore missing stubs in imported modules
 
 [tool.pytest.ini_options]
 # Run pytest with all our checkers, and don't spam us with massive tracebacks on error
-addopts = """
-    --tb=native -vv --doctest-modules --doctest-glob="*.rst"
-    --ignore=src/blueapi/startup
-    """
+addopts = '--tb=native -vv --doctest-modules --doctest-glob="*.rst"'
 # https://iscinumpy.gitlab.io/post/bound-version-constraints/#watch-for-warnings
 filterwarnings = ["error", "ignore::DeprecationWarning"]
 # Doctest python code in docs, python code in src docstrings, test functions in tests
@@ -109,7 +106,6 @@ timeout = 3
 [tool.coverage.run]
 patch = ["subprocess"]
 data_file = "/tmp/blueapi.coverage"
-omit = ["src/blueapi/startup/**/*"]
 
 [tool.coverage.paths]
 # Tests are run from installed location, map back to the src directory


### PR DESCRIPTION
The module previously held sample plan and device configurations and the
project configuration level references were left when the module was
removed.
