### PR TITLE
chore: Add justfile for common tasks

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,4 +1,4 @@
-set dotenv-filename := "tests/system_tests/.env"
+SESSION := "cm12345-1"
 
 compose +ARGS="up -d":
     docker compose -f tests/system_tests/compose.yaml {{ARGS}}
@@ -11,8 +11,12 @@ configure-adsim: (compose "exec" "numtracker" "/app/numtracker" "client" "config
 
 services: compose configure-adsim
 
-blueapi *ARGS="serve":
-    uv run blueapi -c tests/system_tests/config.yaml {{ARGS}}
+serve *OPTS: services
+    source tests/system_tests/.env
+    uv run blueapi -c tests/system_tests/config.yaml {{OPTS}} serve
+
+run PLAN PARAMS:
+    uv run blueapi -c tests/system_tests/config.yaml controller run -i {{ SESSION }} {{ PLAN }} '{{ PARAMS }}'
 
 lint:
     uv run ruff check

--- a/justfile
+++ b/justfile
@@ -19,8 +19,8 @@ run PLAN PARAMS:
     uv run blueapi -c tests/system_tests/config.yaml controller run -i {{ SESSION }} {{ PLAN }} '{{ PARAMS }}'
 
 lint:
-    uv run ruff check
-    uv run pyright
+    uv run prek run --all-files
+    uv run pyright src tests
 
 unit:
     uv run pytest tests/unit_tests

--- a/justfile
+++ b/justfile
@@ -3,6 +3,14 @@ set dotenv-filename := "tests/system_tests/.env"
 compose +ARGS="up -d":
     podman compose -f tests/system_tests/compose.yaml {{ARGS}}
 
+configure-adsim: (compose "exec" "numtracker" "/app/numtracker" "client" "configure" "adsim"
+        "--directory" '/tmp/'
+        "--scan" '{instrument}-{scan_number}'
+        "--detector" '{instrument}-{scan_number}-{detector}'
+        "--number" "43")
+
+services: compose configure-adsim
+
 blueapi *ARGS="serve":
     uv run blueapi -c tests/system_tests/config.yaml {{ARGS}}
 

--- a/justfile
+++ b/justfile
@@ -1,0 +1,17 @@
+set dotenv-filename := "tests/system_tests/.env"
+
+compose +ARGS="up -d":
+    podman compose -f tests/system_tests/compose.yaml {{ARGS}}
+
+blueapi *ARGS="serve":
+    uv run blueapi -c tests/system_tests/config.yaml {{ARGS}}
+
+lint:
+    uv run ruff check
+    uv run pyright
+
+unit:
+    uv run pytest tests/unit_tests
+
+system:
+    uv run pytest tests/system_tests

--- a/justfile
+++ b/justfile
@@ -1,7 +1,7 @@
 set dotenv-filename := "tests/system_tests/.env"
 
 compose +ARGS="up -d":
-    podman compose -f tests/system_tests/compose.yaml {{ARGS}}
+    docker compose -f tests/system_tests/compose.yaml {{ARGS}}
 
 configure-adsim: (compose "exec" "numtracker" "/app/numtracker" "client" "configure" "adsim"
         "--directory" '/tmp/'


### PR DESCRIPTION
Simplifies the various common tasks that should be run during
development.

Can be added to over time but for now mainly wraps running compose
services and calling blueapi so config files don't have to be specified
for every command.
