### PR TITLE
fix: uv-cache dir misplaced

### DIFF
--- a/helm/blueapi/templates/statefulset.yaml
+++ b/helm/blueapi/templates/statefulset.yaml
@@ -101,7 +101,7 @@ spec:
             cp -r /app/.venv/* /artefacts
         env:
         - name: UV_CACHE_DIR
-          value: {{ (.Values.worker.scratch).root }}/.uv-cache
+          value: {{ (.Values.worker.scratch).root }}/.uv-cache-ns
         volumeMounts:
           - name: init-config
             mountPath: "/config"
@@ -205,7 +205,7 @@ spec:
                 name: {{ include "blueapi.fullname" . }}-otel-config
           env:
             - name: UV_CACHE_DIR
-              value: {{ (.Values.worker.scratch).root }}/.uv-cache
+              value: {{ (.Values.worker.scratch).root }}/.uv-cache-ns
             {{- if .Values.debug.enabled }}
             - name: DEBUG_MODE
               value: "ON"           

--- a/helm/blueapi/templates/statefulset.yaml
+++ b/helm/blueapi/templates/statefulset.yaml
@@ -101,7 +101,7 @@ spec:
             cp -r /app/.venv/* /artefacts
         env:
         - name: UV_CACHE_DIR
-          value: {{ (.Values.worker.scratch).root }}/.uv-cache-ns
+          value: /app/.uv-cache
         volumeMounts:
           - name: init-config
             mountPath: "/config"
@@ -205,7 +205,7 @@ spec:
                 name: {{ include "blueapi.fullname" . }}-otel-config
           env:
             - name: UV_CACHE_DIR
-              value: {{ (.Values.worker.scratch).root }}/.uv-cache-ns
+              value: /app/.uv-cache
             {{- if .Values.debug.enabled }}
             - name: DEBUG_MODE
               value: "ON"           


### PR DESCRIPTION
Moving the .uv-cache folder from scratch to /app. This has the benefit of speeding up the population of the cache and removing an error regading not being able to create hard links

fixes #1455