### PR TITLE
feat: Add helper print commands to easily print avaliable devices and plans to user

### DIFF
--- a/src/blueapi/client/client.py
+++ b/src/blueapi/client/client.py
@@ -295,8 +295,8 @@ class BlueapiClient:
         """
         return self._rest.get_plan(name)
 
-    def show_plans(self) -> None:
-        """Command to print all avaliable plans."""
+    def print_plans(self) -> None:
+        """Print all avaliable plans."""
         for name in self.plans:
             print(name)
 
@@ -339,8 +339,8 @@ class BlueapiClient:
 
         return self._rest.get_device(name)
 
-    def show_devices(self) -> None:
-        """Command to print all avaliable devices."""
+    def print_devices(self) -> None:
+        """Print all avaliable devices."""
         for name in self.devices:
             print(name)
 

--- a/src/blueapi/client/client.py
+++ b/src/blueapi/client/client.py
@@ -300,7 +300,7 @@ class BlueapiClient:
         return self._rest.get_plan(name)
 
     def print_plans(self) -> None:
-        """Print all avaliable plans."""
+        """Print all available plans."""
         for name in self.plans:
             print(name)
 
@@ -344,7 +344,7 @@ class BlueapiClient:
         return self._rest.get_device(name)
 
     def print_devices(self) -> None:
-        """Print all avaliable devices."""
+        """Print all available devices."""
         for name in self.devices:
             print(name)
 

--- a/src/blueapi/client/client.py
+++ b/src/blueapi/client/client.py
@@ -295,6 +295,11 @@ class BlueapiClient:
         """
         return self._rest.get_plan(name)
 
+    def show_plans(self) -> None:
+        """Command to print all avaliable plans."""
+        for name in self.plans:
+            print(name)
+
     @start_as_current_span(TRACER)
     @deprecated("devices property")
     def get_devices(self) -> DeviceResponse:
@@ -333,6 +338,11 @@ class BlueapiClient:
         """
 
         return self._rest.get_device(name)
+
+    def show_devices(self) -> None:
+        """Command to print all avaliable devices."""
+        for name in self.devices:
+            print(name)
 
     @property
     @start_as_current_span(TRACER)

--- a/tests/unit_tests/client/test_client.py
+++ b/tests/unit_tests/client/test_client.py
@@ -145,8 +145,8 @@ def test_get_plan(client: BlueapiClient):
     assert client.plans["foo"].model == PLAN
 
 
-def test_show_plans(client: BlueapiClient, capsys: pytest.CaptureFixture):
-    client.show_plans()
+def test_print_plans(client: BlueapiClient, capsys: pytest.CaptureFixture):
+    client.print_plans()
     captured = capsys.readouterr()
     for dev in PLANS.plans:
         assert dev.name in captured.out
@@ -167,8 +167,8 @@ def test_get_device(client: BlueapiClient):
     assert client.devices.foo.model == DEVICE
 
 
-def test_show_devices(client: BlueapiClient, capsys: pytest.CaptureFixture):
-    client.show_devices()
+def test_print_devices(client: BlueapiClient, capsys: pytest.CaptureFixture):
+    client.print_devices()
     captured = capsys.readouterr()
     for dev in DEVICES.devices:
         assert dev.name in captured.out

--- a/tests/unit_tests/client/test_client.py
+++ b/tests/unit_tests/client/test_client.py
@@ -145,6 +145,13 @@ def test_get_plan(client: BlueapiClient):
     assert client.plans["foo"].model == PLAN
 
 
+def test_show_plans(client: BlueapiClient, capsys: pytest.CaptureFixture):
+    client.show_plans()
+    captured = capsys.readouterr()
+    for dev in PLANS.plans:
+        assert dev.name in captured.out
+
+
 def test_get_nonexistant_plan(
     client: BlueapiClient,
 ):
@@ -158,6 +165,13 @@ def test_get_devices(client: BlueapiClient):
 
 def test_get_device(client: BlueapiClient):
     assert client.devices.foo.model == DEVICE
+
+
+def test_show_devices(client: BlueapiClient, capsys: pytest.CaptureFixture):
+    client.show_devices()
+    captured = capsys.readouterr()
+    for dev in DEVICES.devices:
+        assert dev.name in captured.out
 
 
 def test_get_nonexistent_device(


### PR DESCRIPTION
Add small feature to quickly show available devices and plans to user via printing their name from client.

```Python
>>> bc.print_devices()
psk1
psj1
dcm
psi2
jgap
fsj1
...

>>> bc.print_plans()
count(detectors, num=None, delay=None, metadata=None)
spec_scan(detectors, spec, metadata=None)
move(moves, group=None)
move_relative(moves, group=None)
set_absolute(movable, value, group=None, wait=None)
set_relative(movable, value, group=None, wait=None)
sleep(time)
wait(group=None, timeout=None)
...
```