### PR TITLE
docs: add a note to injecting multiple devices docs

### DIFF
--- a/docs/how-to/write-plans.md
+++ b/docs/how-to/write-plans.md
@@ -43,7 +43,7 @@ Then in your plan module:
 ```
 
 > [!NOTE]
-> In order for this to work, the `MyDeviceComposite` needs to be mae available to blueapi by importing it into the `planFunctions` module.
+> In order for this to work, the `MyDeviceComposite` needs to be mae available to blueapi by importing it into the `planFunctions` module where it's needed.
 
 
 ## Injecting Metadata

--- a/docs/how-to/write-plans.md
+++ b/docs/how-to/write-plans.md
@@ -43,7 +43,7 @@ Then in your plan module:
 ```
 
 > [!NOTE]
-> In order for this to work, the `MyDeviceComposite` needs to be mae available to blueapi by importing it into the `planFunctions` module where it's needed.
+> In order for this to work, the `MyDeviceComposite` needs to be made available to blueapi by importing it into the `planFunctions` module where it's needed.
 
 
 ## Injecting Metadata

--- a/docs/how-to/write-plans.md
+++ b/docs/how-to/write-plans.md
@@ -42,6 +42,9 @@ Then in your plan module:
 :language: python
 ```
 
+> [!NOTE]
+> In order for this to work, the `MyDeviceComposite` needs to be mae available to blueapi by importing it into the `planFunctions` module.
+
 
 ## Injecting Metadata
 

--- a/docs/how-to/write-plans.md
+++ b/docs/how-to/write-plans.md
@@ -43,7 +43,7 @@ Then in your plan module:
 ```
 
 > [!NOTE]
-> In order for this to work, the `MyDeviceComposite` needs to be made available to blueapi by importing it into the `planFunctions` module where it's needed.
+> In order for this to work, the `MyDeviceComposite` needs to be made available to blueapi by importing it into the `planFunctions` module where it's needed. Factories for the individual devices within the composite also need to be available in the relevant beamline device module.
 
 
 ## Injecting Metadata


### PR DESCRIPTION
From the documentation page it wasn't obvious that the DeviceComposite would need to be imported into the same `planFunctions` module that will need to make use of it, so adding a small note.
This led to multiple pydantic errors on the beamline that did not help understanding what the actual problem was (issue tbd)