### PR TITLE
fix: invalidate cached plans and devices on environment reload

### DIFF
--- a/src/blueapi/client/client.py
+++ b/src/blueapi/client/client.py
@@ -675,6 +675,10 @@ class BlueapiClient:
             raise BlueskyRemoteControlError(
                 "Failed to tear down the environment"
             ) from e
+        # Invalidate cached plans/devices so subsequent access reflects the
+        # newly reloaded environment rather than the previous one.
+        self.__dict__.pop("plans", None)
+        self.__dict__.pop("devices", None)
         return self._wait_for_reload(
             status,
             timeout,

--- a/tests/unit_tests/client/test_client.py
+++ b/tests/unit_tests/client/test_client.py
@@ -350,6 +350,28 @@ def test_reload_environment_failure(
         client.reload_environment()
 
 
+def test_reload_environment_refreshes_cached_plans_and_devices(
+    client: BlueapiClient,
+    mock_rest: Mock,
+):
+    # Prime caches with the original plans and devices.
+    initial_plans = list(client.plans)
+    initial_devices = list(client.devices)
+    assert {p.name for p in initial_plans} == {"foo", "bar"}
+    assert set(initial_devices) == {"foo", "bar"}
+
+    new_plans = PlanResponse(plans=[PlanModel(name="missing")])
+    new_devices = DeviceResponse(devices=[DeviceModel(name="baz", protocols=[])])
+    mock_rest.get_plans.return_value = new_plans
+    mock_rest.get_devices.return_value = new_devices
+    mock_rest.get_environment.return_value = NEW_ENV
+
+    client.reload_environment()
+
+    assert {p.name for p in client.plans} == {"missing"}
+    assert set(client.devices) == {"baz"}
+
+
 def test_abort(
     client: BlueapiClient,
     mock_rest: Mock,


### PR DESCRIPTION
Fixes #1503

### Instructions to reviewer on how to test:
1. Start a blueapi server, connect a client, and access `bc.plans` / `bc.devices` once to populate the caches.
2. Modify the server-side plan/device modules (add or remove a plan/device) and call `bc.reload_environment()`.
3. Confirm `bc.plans` and `bc.devices` reflect the changes (newly added entries are present, removed entries are gone) without re-creating the client.

### Checks for reviewer
- [ ] Would the PR title make sense to a user on a set of release notes

`reload_environment()` did not invalidate the `@cached_property` values for `plans` and `devices`, so post-reload attribute access returned the pre-reload cache. Pop those entries from `__dict__` after the teardown so the next access recomputes against the new environment. Added a unit test that primes both caches, calls `reload_environment`, and asserts the caches now reflect the new server state.