### PR TITLE
chore: Include all ports in system compose file

### DIFF
--- a/tests/system_tests/compose.yaml
+++ b/tests/system_tests/compose.yaml
@@ -47,9 +47,7 @@ services:
 
   tiled:
     image: ghcr.io/bluesky/tiled:0.2.4
-    network_mode: host
-    ports:
-      - 8407:8407
+    network_mode: host # Port 8407
     environment:
       - PYTHONPATH=/deploy/
     volumes:
@@ -63,9 +61,7 @@ services:
 
   opa:
     image: openpolicyagent/opa:edge-static-debug
-    network_mode: host
-    ports:
-      - 8181:8181
+    network_mode: host # Port 8181
     volumes:
       - "./services/opa_config:/mnt"
     environment:
@@ -75,9 +71,7 @@ services:
       - label=disable
 
   blueapi-oauth2-proxy:
-    network_mode: host
-    ports:
-      - 4180:4180
+    network_mode: host # Port 4180
     image: "quay.io/oauth2-proxy/oauth2-proxy:v7.13.0"
     volumes:
       - ./services/blueapi-oauth2-proxy/:/opt/config
@@ -93,9 +87,7 @@ services:
       - label=disable
 
   tiled-oauth2-proxy:
-    network_mode: host
-    ports:
-      - 4181:4181
+    network_mode: host # Port 4181
     image: "quay.io/oauth2-proxy/oauth2-proxy:v7.13.0"
     volumes:
       - ./services/tiled-oauth2-proxy/:/opt/config

--- a/tests/system_tests/compose.yaml
+++ b/tests/system_tests/compose.yaml
@@ -8,14 +8,14 @@ services:
       - "8406:8000"
     security_opt:
       - label=disable
-    
+
   rabbitmq:
     image: docker.io/rabbitmq:4.0-management
     ports:
-      - "1883:1883"
-      - "5672:5672"
-      - "15672:15672"
-      - "61613:61613"
+      - "1883:1883" # mqtt
+      - "5672:5672" # amqp
+      - "15672:15672" # dashboard
+      - "61613:61613" # stomp
     volumes:
       - type: bind
         source: ./services/rabbitmq_plugins
@@ -48,6 +48,8 @@ services:
   tiled:
     image: ghcr.io/bluesky/tiled:0.2.4
     network_mode: host
+    ports:
+      - 8407:8407
     environment:
       - PYTHONPATH=/deploy/
     volumes:
@@ -62,6 +64,8 @@ services:
   opa:
     image: openpolicyagent/opa:edge-static-debug
     network_mode: host
+    ports:
+      - 8181:8181
     volumes:
       - "./services/opa_config:/mnt"
     environment:
@@ -72,6 +76,8 @@ services:
 
   blueapi-oauth2-proxy:
     network_mode: host
+    ports:
+      - 4180:4180
     image: "quay.io/oauth2-proxy/oauth2-proxy:v7.13.0"
     volumes:
       - ./services/blueapi-oauth2-proxy/:/opt/config
@@ -88,6 +94,8 @@ services:
 
   tiled-oauth2-proxy:
     network_mode: host
+    ports:
+      - 4181:4181
     image: "quay.io/oauth2-proxy/oauth2-proxy:v7.13.0"
     volumes:
       - ./services/tiled-oauth2-proxy/:/opt/config


### PR DESCRIPTION
The ports are not required when they're not being forwarded but
including them means there is one place to look to figure out which
service is running where.
