### PR TITLE
fix: add missing values ApplicationConfig equality check

### DIFF
--- a/src/blueapi/config.py
+++ b/src/blueapi/config.py
@@ -338,6 +338,9 @@ class ApplicationConfig(BlueapiBaseModel):
                 & (self.logging == other.logging)
                 & (self.api == other.api)
                 & (self.opa == other.opa)
+                & (self.tiled == other.tiled)
+                & (self.oidc == other.oidc)
+                & (self.numtracker == other.numtracker)
             )
         return False
 

--- a/src/blueapi/config.py
+++ b/src/blueapi/config.py
@@ -334,13 +334,15 @@ class ApplicationConfig(BlueapiBaseModel):
         if isinstance(other, ApplicationConfig):
             return (
                 (self.stomp == other.stomp)
+                & (self.tiled == other.tiled)
                 & (self.env == other.env)
                 & (self.logging == other.logging)
                 & (self.api == other.api)
-                & (self.opa == other.opa)
-                & (self.tiled == other.tiled)
+                & (self.scratch == other.scratch)
                 & (self.oidc == other.oidc)
+                & (self.auth_token_path == other.auth_token_path)
                 & (self.numtracker == other.numtracker)
+                & (self.opa == other.opa)
             )
         return False
 


### PR DESCRIPTION
Currently the following configs are not checked for equality