### PR TITLE
chore: Add just task to launch repl with blueapi client

### DIFF
--- a/justfile
+++ b/justfile
@@ -34,3 +34,11 @@ system *OPTS:
 coverage:
     uv run pytest tests/unit_tests --cov --cov-report html
     xdg-open htmlcov/index.html
+
+repl:
+    #!/usr/bin/env bash
+    uv run --with ptpython ptpython -i <(cat << EOF
+    from blueapi.client import BlueapiClient
+    bc = BlueapiClient.from_config_file("tests/system_tests/config.yaml").with_instrument_session("cm12345-1")
+    EOF
+    )


### PR DESCRIPTION
    $ just repl

will now launch a repl (using ptpython) with an initialized
BlueapiClient named `bc` using the config from the system tests (the
same used by `just serve` to run the server).
