### PR TITLE
fix: remove `--no-deps` flag in scratch install

### DIFF
--- a/src/blueapi/cli/scratch.py
+++ b/src/blueapi/cli/scratch.py
@@ -133,7 +133,6 @@ def scratch_install(*paths: Path, timeout: float = _DEFAULT_INSTALL_TIMEOUT) -> 
         "uv",
         "pip",
         "install",
-        "--no-deps",
     ]
     for path in paths:
         _validate_directory(path)

--- a/tests/unit_tests/cli/test_scratch.py
+++ b/tests/unit_tests/cli/test_scratch.py
@@ -66,7 +66,7 @@ def test_scratch_install_installs_path(
     scratch_install(directory_path_with_sgid, timeout=1.0)
 
     mock_popen.assert_called_once_with(
-        ["uv", "pip", "install", "--no-deps", "-e", str(directory_path_with_sgid)]
+        ["uv", "pip", "install", "-e", str(directory_path_with_sgid)]
     )
 
 


### PR DESCRIPTION
After removing dodal as dependency in #1534. It becomes difficult for village blueapi to install their plans etc because scratch does install with no dependencies. To make the release usable again we are removing the flag, while we figure out a long term solution for this problem.