### PR TITLE
fix: Remove dodal from default application config

### DIFF
--- a/helm/blueapi/config_schema.json
+++ b/helm/blueapi/config_schema.json
@@ -105,16 +105,7 @@
             "description": "Config for the RunEngine environment",
             "properties": {
                 "sources": {
-                    "default": [
-                        {
-                            "module": "dodal.plans",
-                            "kind": "planFunctions"
-                        },
-                        {
-                            "module": "dodal.plan_stubs.wrapped",
-                            "kind": "planFunctions"
-                        }
-                    ],
+                    "default": [],
                     "items": {
                         "discriminator": {
                             "mapping": {

--- a/helm/blueapi/values.schema.json
+++ b/helm/blueapi/values.schema.json
@@ -554,16 +554,7 @@
                 },
                 "sources": {
                     "title": "Sources",
-                    "default": [
-                        {
-                            "kind": "planFunctions",
-                            "module": "dodal.plans"
-                        },
-                        {
-                            "kind": "planFunctions",
-                            "module": "dodal.plan_stubs.wrapped"
-                        }
-                    ],
+                    "default": [],
                     "type": "array",
                     "items": {
                         "oneOf": [

--- a/src/blueapi/config.py
+++ b/src/blueapi/config.py
@@ -140,10 +140,7 @@ class EnvironmentConfig(BlueapiBaseModel):
             PlanSource | DeviceManagerSource,
             Field(discriminator="kind"),
         ]
-    ] = [
-        PlanSource(module="dodal.plans"),
-        PlanSource(module="dodal.plan_stubs.wrapped"),
-    ]
+    ] = Field(default=[])
     events: WorkerEventConfig = Field(default_factory=WorkerEventConfig)
     metadata: MetadataConfig | None = Field(default=None)
 

--- a/tests/unit_tests/worker/test_task_worker.py
+++ b/tests/unit_tests/worker/test_task_worker.py
@@ -20,7 +20,7 @@ from observability_utils.tracing import (
 )
 from ophyd_async.core import AsyncStatus
 
-from blueapi.config import DeviceManagerSource, EnvironmentConfig
+from blueapi.config import DeviceManagerSource, EnvironmentConfig, PlanSource
 from blueapi.core import BlueskyContext, EventStream
 from blueapi.core.bluesky_types import DataEvent
 from blueapi.service.model import PlanModel
@@ -109,7 +109,12 @@ def second_fake_device() -> FakeDevice:
 @pytest.fixture
 def context(fake_device: FakeDevice, second_fake_device: FakeDevice) -> BlueskyContext:
     ctx = BlueskyContext()
-    ctx_config = EnvironmentConfig()
+    ctx_config = EnvironmentConfig(
+        sources=[
+            PlanSource(module="dodal.plans"),
+            PlanSource(module="dodal.plan_stubs.wrapped"),
+        ]
+    )
     ctx_config.sources.append(DeviceManagerSource(module="devices"))
     ctx.register_plan(failing_plan)
     ctx.register_device(fake_device)
@@ -121,7 +126,12 @@ def context(fake_device: FakeDevice, second_fake_device: FakeDevice) -> BlueskyC
 @pytest.fixture
 def context_without_devices() -> BlueskyContext:
     ctx = BlueskyContext()
-    ctx_config = EnvironmentConfig()
+    ctx_config = EnvironmentConfig(
+        sources=[
+            PlanSource(module="dodal.plans"),
+            PlanSource(module="dodal.plan_stubs.wrapped"),
+        ]
+    )
     ctx_config.sources.append(DeviceManagerSource(module="devices"))
     ctx.with_config(ctx_config)
     return ctx


### PR DESCRIPTION
The default application still included dodal plans as a default. With the change to remove this dependency from the default application this would cause the server to error when trying to fetch plans. This replaces those defaults with an empty list.