### PR TITLE
chore: revert to build pre-commit

### DIFF
--- a/.github/workflows/_system_test.yml
+++ b/.github/workflows/_system_test.yml
@@ -22,7 +22,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
 
       - name: Compose services
-        uses: hoverkraft-tech/compose-action@11beaa1c2dae4e8ed7b1665aa074723b6cecb0e4 # v3.0.0
+        uses: hoverkraft-tech/compose-action@d2bee4f07e8ca410d6b196d00f90c12e7d48c33a # v2.6.0
         with:
           compose-file: "tests/system_tests/compose.yaml"
 

--- a/.github/workflows/_system_test.yml
+++ b/.github/workflows/_system_test.yml
@@ -22,7 +22,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
 
       - name: Compose services
-        uses: hoverkraft-tech/compose-action@d2bee4f07e8ca410d6b196d00f90c12e7d48c33a # v2.6.0
+        uses: hoverkraft-tech/compose-action@11beaa1c2dae4e8ed7b1665aa074723b6cecb0e4 # v3.0.0
         with:
           compose-file: "tests/system_tests/compose.yaml"
 

--- a/prek.toml
+++ b/prek.toml
@@ -29,7 +29,7 @@ hooks = [
 [[repos]]
 repo = "https://github.com/norwoodj/helm-docs"
 rev = "v1.14.2"
-hooks = [{ id = "helm-docs-container", args = ["--chart-search-root=helm"] }]
+hooks = [{ id = "helm-docs-built", args = ["--chart-search-root=helm"] }]
 
 [[repos]]
 repo = "https://github.com/losisin/helm-values-schema-json"
@@ -41,4 +41,4 @@ hooks = [
 [[repos]]
 repo = "https://github.com/gitleaks/gitleaks"
 rev = "v8.30.1"
-hooks = [{ id = "gitleaks-docker" }]
+hooks = [{ id = "gitleaks" }]


### PR DESCRIPTION
Currently docker builds work only outside of the dev container in dls workstation. So reverting this change

```
error: Failed to run hook `helm-docs-container`
  caused by: Failed to run `docker run --rm --tty --user 0:0 --init --volume /workspaces/blueapi:/src:rw,Z --workdir /src jnorwood/helm-docs:latest --chart-search-root=helm`
  caused by: No such file or directory (os error 2)
error: Recipe `lint` failed on line 25 with exit code 2
```