### PR TITLE
chore: remove super-state-machine dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ dependencies = [
     "fastapi>=0.112.0",
     "uvicorn",
     "requests",
-    "super-state-machine",                           # https://github.com/DiamondLightSource/blueapi/issues/553
     "GitPython",
     "event-model==1.23.1",                           # https://github.com/DiamondLightSource/blueapi/issues/684
     "bluesky-stomp>=0.1.6",

--- a/src/blueapi/service/main.py
+++ b/src/blueapi/service/main.py
@@ -5,6 +5,7 @@ from contextlib import asynccontextmanager
 from typing import Annotated
 
 import jwt
+from bluesky._vendor.super_state_machine.errors import TransitionError
 from fastapi import (
     APIRouter,
     BackgroundTasks,
@@ -28,7 +29,6 @@ from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
 from opentelemetry.trace import get_tracer_provider
 from pydantic import ValidationError
 from starlette.responses import JSONResponse
-from super_state_machine.errors import TransitionError
 
 from blueapi.config import ApplicationConfig, OIDCConfig, Tag
 from blueapi.service import interface

--- a/src/blueapi/worker/event.py
+++ b/src/blueapi/worker/event.py
@@ -2,10 +2,10 @@ from collections.abc import Mapping
 from enum import StrEnum
 from typing import Any, Literal, Self
 
+from bluesky._vendor.super_state_machine.extras import PropertyMachine, ProxyString
 from bluesky.run_engine import RunEngineStateMachine
 from pydantic import Field, PydanticSchemaGenerationError, TypeAdapter
 from pydantic_core import PydanticSerializationError
-from super_state_machine.extras import PropertyMachine, ProxyString
 
 from blueapi.utils import BlueapiBaseModel
 

--- a/src/blueapi/worker/task_worker.py
+++ b/src/blueapi/worker/task_worker.py
@@ -8,6 +8,7 @@ from queue import Full, Queue
 from threading import Event, RLock
 from typing import Any, TypeVar
 
+from bluesky._vendor.super_state_machine.errors import TransitionError
 from bluesky.protocols import Status
 from observability_utils.tracing import (
     add_span_attributes,
@@ -20,7 +21,6 @@ from opentelemetry.context import Context, get_current
 from opentelemetry.trace import SpanKind
 from pydantic import Field
 from pydantic.json_schema import SkipJsonSchema
-from super_state_machine.errors import TransitionError
 
 from blueapi.core import (
     OTLP_EXPORT_ENABLED,

--- a/tests/unit_tests/service/test_rest_api.py
+++ b/tests/unit_tests/service/test_rest_api.py
@@ -6,13 +6,13 @@ from unittest.mock import MagicMock, Mock, patch
 
 import jwt
 import pytest
+from bluesky._vendor.super_state_machine.errors import TransitionError
 from bluesky.protocols import Stoppable
 from fastapi import HTTPException, status
 from fastapi.testclient import TestClient
 from httpx2 import Headers
 from pydantic import BaseModel, ValidationError
 from pydantic_core import InitErrorDetails
-from super_state_machine.errors import TransitionError
 
 from blueapi.config import (
     ApplicationConfig,

--- a/uv.lock
+++ b/uv.lock
@@ -466,7 +466,6 @@ dependencies = [
     { name = "pyyaml" },
     { name = "requests" },
     { name = "stomp-py" },
-    { name = "super-state-machine" },
     { name = "tiled", extra = ["client"] },
     { name = "tomlkit" },
     { name = "uvicorn" },
@@ -530,7 +529,6 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "requests" },
     { name = "stomp-py" },
-    { name = "super-state-machine" },
     { name = "tiled", extras = ["client"], specifier = ">=0.2.4" },
     { name = "tomlkit" },
     { name = "uvicorn" },
@@ -5741,15 +5739,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/3f/9d/2eac45f75ce1f9708cf23c5361e74d0b855013d842d3c0aef64ce0667405/stomp_py-9.0.0.tar.gz", hash = "sha256:77b63fdd6cb2fb5e3d7032c5e1cde70c005f498d6096b77827efe71913196464", size = 39701, upload-time = "2026-05-12T19:05:15.221Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a5/99/b010daaf1db86ea6ff3b831e70a5484bfe9c4fbf2f5f2ad6578160c56917/stomp_py-9.0.0-py3-none-any.whl", hash = "sha256:d115c85950b92dad358d11bc361b23d23994d21ff7eef50119f487f718ea4be2", size = 44242, upload-time = "2026-05-12T19:05:16.657Z" },
-]
-
-[[package]]
-name = "super-state-machine"
-version = "2.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/37/6c/6c13e32bf1903f1d71bb21dd8d0b62a7977d514a0d2c399bfaec2e8e4299/super_state_machine-2.1.0.tar.gz", hash = "sha256:dbea42b7440255e76726221a8b1c7980d8928d427bc3c25714c10e0c6f15cfe6", size = 20180, upload-time = "2025-09-06T15:08:56.776Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e3/e9/e1286da32d514ab1bab27b0f28b00e012f4634aa4521fff7a17bfd9c302a/super_state_machine-2.1.0-py2.py3-none-any.whl", hash = "sha256:c6a4d07202486096004055c77824d979c59248ea23b689addb46a5867e259821", size = 8134, upload-time = "2025-09-06T15:08:55.275Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
closes #555 

Using _vendor because we are only using it for typing and errors