### PR TITLE
test: fix pytest-xdist and pytest-timeout working together

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,11 +103,11 @@ addopts = '--tb=native -vv --doctest-modules --doctest-glob="*.rst"'
 # https://iscinumpy.gitlab.io/post/bound-version-constraints/#watch-for-warnings
 filterwarnings = ["error", "ignore::DeprecationWarning"]
 # Doctest python code in docs, python code in src docstrings, test functions in tests
-timeout_method = "thread"
-timeout_func_only = true
 testpaths = "docs src tests"
 asyncio_mode = "auto"
 timeout = 1.5
+timeout_method = "thread"
+timeout_func_only = true
 [tool.coverage.run]
 patch = ["subprocess"]
 data_file = "/tmp/blueapi.coverage"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,7 +107,7 @@ timeout_method = "thread"
 timeout_func_only = true
 testpaths = "docs src tests"
 asyncio_mode = "auto"
-timeout = 1
+timeout = 1.5
 [tool.coverage.run]
 patch = ["subprocess"]
 data_file = "/tmp/blueapi.coverage"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,10 +103,11 @@ addopts = '--tb=native -vv --doctest-modules --doctest-glob="*.rst"'
 # https://iscinumpy.gitlab.io/post/bound-version-constraints/#watch-for-warnings
 filterwarnings = ["error", "ignore::DeprecationWarning"]
 # Doctest python code in docs, python code in src docstrings, test functions in tests
+timeout_method = "thread"
+timeout_func_only = true
 testpaths = "docs src tests"
 asyncio_mode = "auto"
-timeout = 10
-
+timeout = 1
 [tool.coverage.run]
 patch = ["subprocess"]
 data_file = "/tmp/blueapi.coverage"
@@ -160,6 +161,8 @@ commands = [
         "pytest",
         "-n",
         "logical",
+        "--max-worker-restart",
+        "0",
         "tests/unit_tests",
         "--cov=blueapi",
         "--cov-report",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,7 +106,7 @@ filterwarnings = ["error", "ignore::DeprecationWarning"]
 testpaths = "docs src tests"
 asyncio_mode = "auto"
 # Timeout settings for pytest-timeout 
-timeout = 1.5
+timeout = 10
 # Timeout using thread method to make pytest-timeout work with pytest-xdist
 timeout_method = "thread"
 timeout_func_only = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,7 +105,9 @@ filterwarnings = ["error", "ignore::DeprecationWarning"]
 # Doctest python code in docs, python code in src docstrings, test functions in tests
 testpaths = "docs src tests"
 asyncio_mode = "auto"
+# Timeout settings for pytest-timeout 
 timeout = 1.5
+# Timeout using thread method to make pytest-timeout work with pytest-xdist
 timeout_method = "thread"
 timeout_func_only = true
 [tool.coverage.run]
@@ -161,6 +163,7 @@ commands = [
         "pytest",
         "-n",
         "logical",
+        # Disable worker restarts so pytest-xdist does not rerun a test in another worker after pytest-timeout triggers
         "--max-worker-restart",
         "0",
         "tests/unit_tests",


### PR DESCRIPTION
When I had done the PR for pyxdist I increased the timeout to 10 seconds as they where not playing nice with eachother.

I think PR I have gone through the docs/issues and found out that we can use the commands as in PR to make them work nicely with each other