### PR TITLE
test: Shrink the spec-scan used in system tests

### DIFF
--- a/tests/system_tests/test_blueapi_system.py
+++ b/tests/system_tests/test_blueapi_system.py
@@ -541,7 +541,7 @@ def test_delete_current_environment(client: BlueapiClient):
                     "detectors": [
                         "det",
                     ],
-                    "num": 5,
+                    "num": 3,
                 },
                 instrument_session=VALID_INSTRUMENT_SESSION[User.alice],
             ),
@@ -557,14 +557,14 @@ def test_delete_current_environment(client: BlueapiClient):
                         "outer": {
                             "axis": "stage.x",
                             "start": 0.0,
-                            "stop": 10.0,
+                            "stop": 0.4,
                             "num": 2,
                             "type": "Linspace",
                         },
                         "inner": {
                             "axis": "stage.theta",
                             "start": 5.0,
-                            "stop": 15.0,
+                            "stop": 5.3,
                             "num": 3,
                             "type": "Linspace",
                         },
@@ -634,7 +634,7 @@ def test_plan_runs(
             name="set_absolute",
             params={
                 "movable": "stage.x",
-                "value": 4.0,
+                "value": 1.0,
             },
             instrument_session=VALID_INSTRUMENT_SESSION[User.alice],
         ),


### PR DESCRIPTION
The test still covers all the same code paths but running a smaller
scan with the simulated motors takes much less time.

As this is one of the longest tests in the system test suite, the
runtime is reduced significantly. On this machine, the run time drops
from ~1m to ~15s.
