### PR TITLE
Add a logout method to blueapi client

### DIFF
--- a/src/blueapi/client/client.py
+++ b/src/blueapi/client/client.py
@@ -774,6 +774,17 @@ class BlueapiClient:
             else:
                 print("Server is not configured to use authentication!")
 
+    def logout(self, token_path: Path | None = None):
+        try:
+            auth: SessionManager = SessionManager.from_cache(token_path)
+            auth.logout()
+        except FileNotFoundError:
+            print("Logged out")
+        except ValueError as e:
+            print(f"Invalid login token: {e}")
+        except Exception as e:
+            print(f"Failed to logout from blueapi with error: {e}")
+
 
 class PlanFailedError(Exception):
     def __init__(self, typ: str, message: str):

--- a/tests/unit_tests/client/test_client.py
+++ b/tests/unit_tests/client/test_client.py
@@ -1000,3 +1000,19 @@ def test_client_login_no_oidc(
     client.login()
 
     mock_session_manager.assert_not_called()
+
+
+@patch("blueapi.client.client.SessionManager")
+def test_client_logout(mock_session_manager: Mock, client: BlueapiClient):
+    client.logout()
+
+    mock_session_manager.from_cache.assert_called_once()
+    mock_session_manager.from_cache.return_value.logout.assert_called_once()
+
+
+@patch("blueapi.client.client.SessionManager")
+def test_client_logout_invalid_token(mock_session_manager: Mock, client: BlueapiClient):
+    mock_session_manager.from_cache.side_effect = ValueError("No token")
+
+    client.logout()
+    mock_session_manager.from_cache.return_value.logout.assert_not_called()


### PR DESCRIPTION
For python applications using the BlueapiClient directly, currently there is a way to login but not one to logout available.