### PR TITLE
ci: publish docs only on tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
   publish:
     needs: [docs]
     # don't publish a pages site in the fork's org
-    if: github.repository == 'DiamondLightSource/blueapi'
+    if: github.repository == 'DiamondLightSource/blueapi' && github.ref_type == 'tag' # publish only on tags
     uses: ./.github/workflows/publish-dispatch.yml # your workflow (below)
     with:
       version-name: ${{ needs.docs.outputs.version-name }}


### PR DESCRIPTION
Currently we are publishing GitHub page on every branch. 
We should be only building docs on each branch and publish only on tags