### PR TITLE
ci: change fetch depth for system_tests

### DIFF
--- a/.github/workflows/_system_test.yml
+++ b/.github/workflows/_system_test.yml
@@ -13,8 +13,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
         with:
-          # Need this to get version number from last tag
-          fetch-depth: 0
+          fetch-depth: 1
           # Check out example services
           submodules: true
 


### PR DESCRIPTION
It is not required for system test to fetch the entire history