### PR TITLE
refactor: Add defaults for authZ policy

### DIFF
--- a/helm/blueapi/config_schema.json
+++ b/helm/blueapi/config_schema.json
@@ -301,23 +301,21 @@
                     "type": "string"
                 },
                 "tiled_service_account_check": {
+                    "default": "blueapi/tiled_service_account_for_beamline",
                     "title": "Tiled Service Account Check",
                     "type": "string"
                 },
                 "submit_task_check": {
+                    "default": "blueapi/write_to_beamline_visit",
                     "title": "Submit Task Check",
                     "type": "string"
                 },
                 "admin_check": {
+                    "default": "admin/admin",
                     "title": "Admin Check",
                     "type": "string"
                 }
             },
-            "required": [
-                "tiled_service_account_check",
-                "submit_task_check",
-                "admin_check"
-            ],
             "title": "OpaConfig",
             "type": "object",
             "$id": "OpaConfig"

--- a/helm/blueapi/values.schema.json
+++ b/helm/blueapi/values.schema.json
@@ -714,14 +714,10 @@
             "$id": "OpaConfig",
             "title": "OpaConfig",
             "type": "object",
-            "required": [
-                "tiled_service_account_check",
-                "submit_task_check",
-                "admin_check"
-            ],
             "properties": {
                 "admin_check": {
                     "title": "Admin Check",
+                    "default": "admin/admin",
                     "type": "string"
                 },
                 "audience": {
@@ -739,10 +735,12 @@
                 },
                 "submit_task_check": {
                     "title": "Submit Task Check",
+                    "default": "blueapi/write_to_beamline_visit",
                     "type": "string"
                 },
                 "tiled_service_account_check": {
                     "title": "Tiled Service Account Check",
+                    "default": "blueapi/tiled_service_account_for_beamline",
                     "type": "string"
                 }
             },

--- a/src/blueapi/config.py
+++ b/src/blueapi/config.py
@@ -306,9 +306,9 @@ class Tag(StrEnum):
 class OpaConfig(BlueapiBaseModel):
     root: HttpUrl = HttpUrl("http://localhost:8181")
     audience: str = "account"
-    tiled_service_account_check: str
-    submit_task_check: str
-    admin_check: str
+    tiled_service_account_check: str = "blueapi/tiled_service_account_for_beamline"
+    submit_task_check: str = "blueapi/write_to_beamline_visit"
+    admin_check: str = "admin/admin"
 
 
 class ApplicationConfig(BlueapiBaseModel):

--- a/tests/system_tests/config.yaml
+++ b/tests/system_tests/config.yaml
@@ -27,6 +27,3 @@ oidc:
   client_audience: "ixx-blueapi"
 opa:
   root: "http://localhost:8181/v1/data/diamond/policy/"
-  tiled_service_account_check: "blueapi/tiled_service_account_for_beamline"
-  submit_task_check: "blueapi/write_to_beamline_visit"
-  admin_check: "admin/admin"


### PR DESCRIPTION
It feels slightly awkward to have to specify the policy values explicitly. I think having sensible defaults would provide a better UX.

They could also be included in Copier, but having them as defaults would mean one less thing to worry about when running `copier update`.
