### PR TITLE
ci: cancel superseded CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: CI
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
     branches:


### PR DESCRIPTION
Run CI on only the latest commit of the branch, to save compute for Planet A

I'll open a PR in copier if this works in the merge_queue