### PR TITLE
test: Use single thread for tests when passing options

### DIFF
--- a/justfile
+++ b/justfile
@@ -25,8 +25,8 @@ lint:
     uv run prek run --all-files
     uv run pyright src tests
 
-unit *OPTS:
-    uv run pytest -n logical tests/unit_tests {{ OPTS }}
+unit *OPTS="-n logical":
+    uv run pytest tests/unit_tests {{ OPTS }}
 
 system *OPTS:
     uv run pytest tests/system_tests {{ OPTS }}


### PR DESCRIPTION
If specifying limited tests via options such as `-k specific_test` or
only running previous failures with `--lf`, the overhead of creating
additional workers and gathering results can be longer than the time
saved by running tests in parallel.

Leaving the multi-thread options as default means running `just unit`
still runs the whole suite as quickly as it can.
