### PR TITLE
fix: Make just container runner configurable in justfile

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,7 +1,8 @@
 SESSION := "cm12345-1"
+RUNNER := "docker"
 
 compose +ARGS="up -d":
-    docker compose -f tests/system_tests/compose.yaml {{ARGS}}
+    {{ RUNNER }} compose -f tests/system_tests/compose.yaml {{ARGS}}
 
 configure-adsim: (compose "exec" "numtracker" "/app/numtracker" "client" "configure" "adsim"
         "--directory" '/tmp/'


### PR DESCRIPTION
On machines that use `podman` instead of docker and don't have an alias in place, just needs to use `podman`. To support both, the runner still uses `docker` by default but can be configured to use `podman` via

    $ just RUNNER=podman services
