### PR TITLE
fix: prevent RUNNER detection failure

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,6 +1,13 @@
 SESSION := "cm12345-1"
 RUNNER := `command -v docker || command -v podman || true`
 
+_check-runner:
+    #!/usr/bin/env bash
+    if [[ "{{ RUNNER }}" == "" ]]; then
+        echo "{{ style('error') }}error{{ NORMAL }}: No container runtime available - either podman or docker is required"
+        exit 1
+    fi
+
 default: compose serve
 
 init-example-services:
@@ -10,7 +17,7 @@ init-example-services:
         git submodule update --init example-services
     fi
 
-compose +ARGS="up -d --no-recreate": init-example-services
+compose +ARGS="up -d --no-recreate": init-example-services _check-runner
     {{ RUNNER }} compose -f tests/system_tests/compose.yaml {{ARGS}}
 
 serve *OPTS:

--- a/justfile
+++ b/justfile
@@ -1,5 +1,5 @@
 SESSION := "cm12345-1"
-RUNNER := `command -v docker || command -v podman`
+RUNNER := `command -v docker || command -v podman || true`
 
 default: compose serve
 


### PR DESCRIPTION
Append `|| true` so the justfile can still be parsed/used on systems without a container runtime like docker or podman, instead of erroring out at command substitution time.