### PR TITLE
refactor: use directory name instead of pypi name

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,6 @@ dependencies = [
     "opentelemetry-instrumentation-fastapi>=0.48b0",
     "observability-utils>=0.1.4",
     "pyjwt[crypto]",
-    "tomlkit",
     "graypy>=2.1.0",
     "httpx>=0.28.1",
     "aiohttp>=3.13.5",

--- a/src/blueapi/cli/scratch.py
+++ b/src/blueapi/cli/scratch.py
@@ -8,7 +8,6 @@ from pathlib import Path
 from subprocess import Popen
 
 from git import Repo
-from tomlkit import parse
 
 from blueapi.config import FORBIDDEN_OWN_REMOTE_URL, ScratchConfig
 from blueapi.service.model import PackageInfo, PythonEnvironmentResponse, SourceInfo
@@ -180,15 +179,6 @@ def _validate_directory(path: Path) -> None:
         raise KeyError(f"{path}: Is a file, not a directory")
 
 
-def _get_project_name_from_pyproject(path: Path) -> str:
-    pyproject_path = path / "pyproject.toml"
-    if pyproject_path.exists():
-        with pyproject_path.open("r", encoding="utf-8") as file:
-            toml_data = parse(file.read())
-        return toml_data.get("project", {}).get("name", "")
-    return ""
-
-
 def _fetch_installed_packages_details() -> list[PackageInfo]:
     installed_packages = importlib.metadata.distributions()
     return [
@@ -234,7 +224,7 @@ def get_python_environment(
                 if repo.remotes
                 else f"UNKNOWN REMOTE @{branch}"
             )
-            package_name = _get_project_name_from_pyproject(local_directory)
+            package_name = local_directory.name
             package_location = ""
 
             packages.append(

--- a/tests/unit_tests/cli/test_scratch.py
+++ b/tests/unit_tests/cli/test_scratch.py
@@ -10,7 +10,6 @@ from git import Repo
 
 from blueapi.cli.scratch import (
     _fetch_installed_packages_details,
-    _get_project_name_from_pyproject,
     ensure_repo,
     get_python_environment,
     scratch_install,
@@ -404,9 +403,7 @@ def config(directory_path_with_sgid: Path) -> ScratchConfig:
 
 @patch("blueapi.cli.scratch.Repo")
 @patch("blueapi.cli.scratch._fetch_installed_packages_details")
-@patch("blueapi.cli.scratch._get_project_name_from_pyproject")
 def test_get_python_env_returns_correct_packages(
-    mock_get_project_name: Mock,
     mock_fetch_installed_packages: Mock,
     mock_repo: Mock,
     directory_path_with_sgid: Path,
@@ -429,7 +426,6 @@ def test_get_python_env_returns_correct_packages(
 
     mock_repo.side_effect = [mock_repo_1, mock_repo_2]
 
-    mock_get_project_name.side_effect = ["foo-package", "bar-package"]
     mock_fetch_installed_packages.return_value = [
         PackageInfo(
             name="package-01",
@@ -443,14 +439,14 @@ def test_get_python_env_returns_correct_packages(
 
     assert response.installed_packages == [
         PackageInfo(
-            name="bar-package",
+            name="bar",
             version="http://example.com/bar.git @adsad23123",
             location="",
             is_dirty=True,
             source=SourceInfo.SCRATCH,
         ),
         PackageInfo(
-            name="foo-package",
+            name="foo",
             version="http://example.com/foo.git @main",
             location="",
             is_dirty=False,
@@ -468,9 +464,7 @@ def test_get_python_env_returns_correct_packages(
 
 @patch("blueapi.cli.scratch.Repo")
 @patch("blueapi.cli.scratch._fetch_installed_packages_details")
-@patch("blueapi.cli.scratch._get_project_name_from_pyproject")
 def test_fetch_python_env_with_identical_packages(
-    mock_get_project_name: Mock,
     mock_fetch_installed_packages: Mock,
     mock_repo: Mock,
     directory_path_with_sgid: Path,
@@ -484,10 +478,9 @@ def test_fetch_python_env_with_identical_packages(
 
     mock_repo.return_value = mock_repo_instance
 
-    mock_get_project_name.return_value = "foo-package"
     mock_fetch_installed_packages.return_value = [
         PackageInfo(
-            name="foo-package",
+            name="foo",
             version="http://example.com/foo.git @main",
             location="/some/location",
             is_dirty=False,
@@ -507,7 +500,7 @@ def test_fetch_python_env_with_identical_packages(
 
     assert response.installed_packages == [
         PackageInfo(
-            name="foo-package",
+            name="foo",
             version="http://example.com/foo.git @main",
             location="/some/location &&",
             is_dirty=False,
@@ -539,9 +532,7 @@ def test_fetch_installed_packages_details_returns_correct_packages(mock_distribu
 
 @patch("blueapi.cli.scratch.Repo")
 @patch("blueapi.cli.scratch._fetch_installed_packages_details")
-@patch("blueapi.cli.scratch._get_project_name_from_pyproject")
 def test_get_python_env_filters_by_name_and_source(
-    mock_get_project_name: Mock,
     mock_fetch_installed_packages: Mock,
     mock_repo: Mock,
     directory_path_with_sgid: Path,
@@ -555,7 +546,6 @@ def test_get_python_env_filters_by_name_and_source(
     mock_repo_instance.remotes = [Mock(url="http://example.com/foo.git")]
     mock_repo.return_value = mock_repo_instance
 
-    mock_get_project_name.return_value = "foo-package"
     mock_fetch_installed_packages.return_value = [
         PackageInfo(
             name="bar-package",
@@ -575,10 +565,10 @@ def test_get_python_env_filters_by_name_and_source(
         ],
     )
     # Test filtering by name
-    response_by_name = get_python_environment(config, name="foo-package")
+    response_by_name = get_python_environment(config, name="foo")
     assert response_by_name.installed_packages == [
         PackageInfo(
-            name="foo-package",
+            name="foo",
             version="http://example.com/foo.git @main",
             location="",
             is_dirty=False,
@@ -590,51 +580,10 @@ def test_get_python_env_filters_by_name_and_source(
     response_by_source = get_python_environment(config, source=SourceInfo.SCRATCH)
     assert response_by_source.installed_packages == [
         PackageInfo(
-            name="foo-package",
+            name="foo",
             version="http://example.com/foo.git @main",
             location="",
             is_dirty=False,
             source=SourceInfo.SCRATCH,
         )
     ]
-
-
-@pytest.fixture
-def pyproject_file(tmp_path: Path) -> Generator[Path]:
-    pyproject_path = tmp_path / "pyproject.toml"
-    with pyproject_path.open("w") as f:
-        f.write(
-            """
-            [project]
-            name = "example-project"
-            """
-        )
-    yield pyproject_path
-    os.remove(pyproject_path)
-
-
-def test_get_project_name_from_pyproject_returns_name(pyproject_file: Path):
-    project_name = _get_project_name_from_pyproject(pyproject_file.parent)
-    assert project_name == "example-project"
-
-
-def test_get_project_name_from_pyproject_returns_empty_if_no_pyproject(
-    tmp_path: Path,
-):
-    project_name = _get_project_name_from_pyproject(tmp_path)
-    assert project_name == ""
-
-
-def test_get_project_name_from_pyproject_returns_empty_if_no_name_key(
-    tmp_path: Path,
-):
-    pyproject_path = tmp_path / "pyproject.toml"
-    with pyproject_path.open("w") as f:
-        f.write(
-            """
-            [project]
-            version = "1.0.0"
-            """
-        )
-    project_name = _get_project_name_from_pyproject(tmp_path)
-    assert project_name == ""

--- a/uv.lock
+++ b/uv.lock
@@ -470,7 +470,6 @@ dependencies = [
     { name = "requests" },
     { name = "stomp-py" },
     { name = "tiled", extra = ["client"] },
-    { name = "tomlkit" },
     { name = "uvicorn" },
 ]
 
@@ -541,7 +540,6 @@ requires-dist = [
     { name = "requests" },
     { name = "stomp-py" },
     { name = "tiled", extras = ["client"], specifier = ">=0.2.4" },
-    { name = "tomlkit" },
     { name = "uvicorn", specifier = ">=0.52.1" },
 ]
 provides-extras = ["demo"]
@@ -6214,15 +6212,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/19/75/241269d1da26b624c0d5e110e8149093c759b7a286138f4efd61a60e75fe/tomli_w-1.2.0.tar.gz", hash = "sha256:2dd14fac5a47c27be9cd4c976af5a12d87fb1f0b4512f81d69cce3b35ae25021", size = 7184, upload-time = "2025-01-15T12:07:24.262Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl", hash = "sha256:188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90", size = 6675, upload-time = "2025-01-15T12:07:22.074Z" },
-]
-
-[[package]]
-name = "tomlkit"
-version = "0.15.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/94/96/e07752635b98536177fa1f37671c8f3cdde2e724c6bcf6034b2cfb571565/tomlkit-0.15.1.tar.gz", hash = "sha256:e25bbf38843005246210a12982776f27f99cb9be67160e14434d0c0d21ee1e97", size = 180129, upload-time = "2026-07-17T01:48:04.562Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/13/bc/8c13eb66537dce1d2bd3a57132902f38d0e7f5bb46fa9f4daed9fe9d76ee/tomlkit-0.15.1-py3-none-any.whl", hash = "sha256:177a05aece5a8ca5266fd3c448abb47b8d352f09d477d3ca8332db4d89b24304", size = 49449, upload-time = "2026-07-17T01:48:05.728Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
More than a PR this is to explore should we have 

 `dodal` as appose to [`dls-dodal`](https://github.com/DiamondLightSource/dodal/blob/3c6eab0c1079178192a23c4c6437a9d4d9287f73/pyproject.toml#L6) 